### PR TITLE
Stream file downloads to save memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,12 +283,14 @@ dependencies = [
  "clap",
  "cloudsync-common",
  "cloudsync-server",
+ "futures",
  "redb",
  "reqwest",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
 ]
@@ -458,12 +460,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -471,6 +489,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -507,6 +536,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 axum = { version = "0.8", features = ["multipart", "macros"] }
 tokio = { version = "1.0", features = ["full"] }
+tokio-util = { version = "0.7", features = ["io"] }
 redb = { version = "2.0" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/cloudsync-client/Cargo.toml
+++ b/crates/cloudsync-client/Cargo.toml
@@ -13,8 +13,10 @@ anyhow = { workspace = true }
 reqwest = { workspace = true }
 redb = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
+futures = "0.3"
 
 [dev-dependencies]
 cloudsync-server = { path = "../cloudsync-server" }

--- a/crates/cloudsync-client/src/client.rs
+++ b/crates/cloudsync-client/src/client.rs
@@ -2,8 +2,10 @@ use cloudsync_common::{
     CreateFileResponse, DeleteFileResponse, FinalizeUploadResponse, GetUploadResponse,
     InitUploadRequest, InitUploadResponse, ListFilesResponse,
 };
+use tokio::io::AsyncRead;
 
 use crate::sync::SyncApi;
+use futures::TryStreamExt;
 
 pub struct SyncClient {
     server_url: String,
@@ -76,20 +78,22 @@ impl SyncApi for SyncClient {
         Ok(serde_json::from_slice::<CreateFileResponse>(&bytes)?)
     }
 
-    async fn get_file(&self, path: &str) -> anyhow::Result<Vec<u8>> {
+    async fn get_file(&self, path: &str) -> anyhow::Result<Box<dyn AsyncRead + Unpin + Send>> {
         let url = format!("{}/{}/{}", self.server_url, "api/v1/files", path);
         tracing::debug!("request: {} {}", "get", &url);
         let resp = self.client.get(url).bearer_auth(&self.token).send().await?;
         let status = resp.status();
-        let bytes = resp.bytes().await?;
         if !status.is_success() {
             anyhow::bail!(
                 "Server error {}: {}",
                 status,
-                String::from_utf8_lossy(&bytes)
+                String::from_utf8_lossy(&resp.bytes().await?)
             )
         }
-        Ok(bytes.to_vec())
+        let bytes_stream = resp.bytes_stream();
+        let stream = bytes_stream.map_err(std::io::Error::other);
+        let reader = tokio_util::io::StreamReader::new(stream);
+        Ok(Box::new(reader))
     }
 
     async fn delete_file(&self, path: &str) -> anyhow::Result<DeleteFileResponse> {

--- a/crates/cloudsync-client/src/sync.rs
+++ b/crates/cloudsync-client/src/sync.rs
@@ -7,6 +7,7 @@ use cloudsync_common::{
 };
 use redb::Database;
 use serde::{Deserialize, Serialize};
+use tokio::io::AsyncRead;
 
 use crate::db;
 use crate::scanner::{self, scan_dir};
@@ -18,7 +19,7 @@ pub trait SyncApi {
     async fn list_files(&self) -> anyhow::Result<ListFilesResponse>;
     async fn create_file(&self, path: &str, content: Vec<u8>)
     -> anyhow::Result<CreateFileResponse>;
-    async fn get_file(&self, path: &str) -> anyhow::Result<Vec<u8>>;
+    async fn get_file(&self, path: &str) -> anyhow::Result<Box<dyn AsyncRead + Unpin + Send>>;
     async fn delete_file(&self, path: &str) -> anyhow::Result<DeleteFileResponse>;
     async fn init_upload(&self, request: InitUploadRequest) -> anyhow::Result<InitUploadResponse>;
     async fn send_chunk(
@@ -202,7 +203,6 @@ async fn pull_single_file(
                 let hash = hash_file(local_path)?;
                 if hash != record.local_hash {
                     println!("Conflict: {} changed locally and on server", file_meta.path);
-                    let server_content = sync_client.get_file(&file_meta.path).await?;
                     let rel_path: &Path = std::path::Path::new(&file_meta.path);
                     let stem = rel_path.file_stem().unwrap_or_default().to_str().unwrap();
                     let ext = rel_path
@@ -214,23 +214,26 @@ async fn pull_single_file(
                     let conflict_path = sync_root
                         .join(&file_meta.path)
                         .with_file_name(conflict_path);
-                    std::fs::write(&conflict_path, server_content)?;
+                    let mut file = tokio::fs::File::create(&conflict_path).await?;
+                    let mut stream_reader = sync_client.get_file(&file_meta.path).await?;
+                    tokio::io::copy(&mut stream_reader, &mut file).await?;
                     println!("Conflict: resolve conflict in {}", conflict_path.display());
                     return Ok(());
                 }
             }
         }
     }
-    let content = sync_client.get_file(&file_meta.path).await?;
     let local_path = &sync_root.join(&file_meta.path);
     let parent_dir = std::path::Path::new(local_path).parent();
     if let Some(parent_dir) = parent_dir {
         std::fs::create_dir_all(parent_dir)?;
     };
-    std::fs::write(local_path, &content)?;
+    let mut stream_reader = sync_client.get_file(&file_meta.path).await?;
+    let mut file = tokio::fs::File::create(local_path).await?;
+    tokio::io::copy(&mut stream_reader, &mut file).await?;
     let sync_record = SyncRecord {
         path: file_meta.path.clone(),
-        local_hash: hash_bytes(&content),
+        local_hash: hash_file(local_path)?,
         server_version: file_meta.version,
     };
     db::put(db, sync_record)?;
@@ -375,12 +378,12 @@ mod tests {
             })
         }
 
-        async fn get_file(&self, path: &str) -> anyhow::Result<Vec<u8>> {
+        async fn get_file(&self, path: &str) -> anyhow::Result<Box<dyn AsyncRead + Unpin + Send>> {
             if self.fail_path.borrow().as_deref() == Some(path) {
                 anyhow::bail!("error");
             }
             *self.get_count.borrow_mut() += 1;
-            Ok(Vec::new())
+            Ok(Box::new(std::io::Cursor::new(Vec::new())))
         }
 
         async fn delete_file(&self, _path: &str) -> anyhow::Result<DeleteFileResponse> {

--- a/crates/cloudsync-server/Cargo.toml
+++ b/crates/cloudsync-server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 cloudsync-common = { path = "../cloudsync-common" }
 axum = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { version = "0.7", features = ["io"] }
 redb = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/crates/cloudsync-server/Cargo.toml
+++ b/crates/cloudsync-server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 cloudsync-common = { path = "../cloudsync-common" }
 axum = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { version = "0.7", features = ["io"] }
+tokio-util = { workspace = true }
 redb = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/crates/cloudsync-server/src/app.rs
+++ b/crates/cloudsync-server/src/app.rs
@@ -261,7 +261,8 @@ pub fn create_app(state: AppState) -> Router {
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth_layer,
-        ));
+        ))
+        .layer(DefaultBodyLimit::max(5 * 1024 * 1024)); // 4MB + overhead
     Router::<AppState>::new()
         .route("/api/v1/health", get(get_health))
         .merge(auth_router)

--- a/crates/cloudsync-server/src/app.rs
+++ b/crates/cloudsync-server/src/app.rs
@@ -97,7 +97,7 @@ async fn delete_file(
 async fn get_file(
     State(state): State<AppState>,
     Path(path): Path<String>,
-) -> Result<Vec<u8>, AppError> {
+) -> Result<impl IntoResponse, AppError> {
     let db: Arc<Database> = state.db;
     let file_meta = db::get(&db, &path)?;
     let Some(file_meta) = file_meta else {
@@ -113,8 +113,13 @@ async fn get_file(
         file_meta.version
     );
     let content_hash = file_meta.content_hash;
-    let content = storage::read(&state.storage_dir, &content_hash)?;
-    Ok(content)
+    let file = storage::read_async(&state.storage_dir, &content_hash).await?;
+    let reader_stream = tokio_util::io::ReaderStream::new(file);
+    let headers = [(
+        axum::http::header::CONTENT_LENGTH,
+        file_meta.size.to_string(),
+    )];
+    Ok((headers, axum::body::Body::from_stream(reader_stream)))
 }
 
 async fn create_upload(

--- a/crates/cloudsync-server/src/storage.rs
+++ b/crates/cloudsync-server/src/storage.rs
@@ -1,12 +1,5 @@
 use cloudsync_common::hash_bytes;
 
-pub fn read(data_dir: &str, content_hash: &str) -> anyhow::Result<Vec<u8>> {
-    let dir = std::path::Path::new(data_dir).join(&content_hash[0..2]);
-    let path = dir.join(content_hash);
-    let res = std::fs::read(path)?;
-    Ok(res)
-}
-
 pub fn write(data_dir: &str, content: &[u8]) -> anyhow::Result<String> {
     let content_hash = hash_bytes(content);
     let dir = std::path::Path::new(data_dir).join(&content_hash[0..2]);
@@ -14,6 +7,13 @@ pub fn write(data_dir: &str, content: &[u8]) -> anyhow::Result<String> {
     std::fs::create_dir_all(dir)?;
     std::fs::write(&path, content)?;
     Ok(content_hash)
+}
+
+pub async fn read_async(data_dir: &str, content_hash: &str) -> anyhow::Result<tokio::fs::File> {
+    let dir = std::path::Path::new(data_dir).join(&content_hash[0..2]);
+    let path = dir.join(content_hash);
+    let file = tokio::fs::File::open(path).await?;
+    Ok(file)
 }
 
 pub fn get_storage_path(data_dir: &str, total_hash: &str) -> std::path::PathBuf {
@@ -26,9 +26,10 @@ pub fn get_storage_path(data_dir: &str, total_hash: &str) -> std::path::PathBuf 
 mod test {
     use super::*;
     use tempfile::TempDir;
+    use tokio::io::AsyncReadExt;
 
-    #[test]
-    fn test_write_read() {
+    #[tokio::test]
+    async fn test_write_read() {
         let dir = TempDir::new().unwrap();
         let dir = dir.path().to_str().unwrap();
 
@@ -37,7 +38,9 @@ mod test {
 
         assert_eq!(hash, hash_bytes(bytes));
 
-        let content = read(dir, &hash).unwrap();
-        assert_eq!(content.as_slice(), bytes);
+        let file = read_async(dir, &hash).await.unwrap();
+        let mut buf = Vec::new();
+        file.take(1000).read_to_end(&mut buf).await.unwrap();
+        assert_eq!(buf.as_slice(), bytes);
     }
 }


### PR DESCRIPTION
Closes #5

## Summary
- Server streams file responses via `ReaderStream` instead of loading into `Vec<u8>`, with `Content-Length` header
- Client streams downloads to disk via `StreamReader` + `tokio::io::copy` instead of buffering with `.bytes().await`
- Lowered global body limit from 50MB to 5MB since large uploads go through chunked path
- Centralized `tokio-util` as a workspace dependency

## Test plan
- [x] Existing integration tests pass (push/pull round-trip with small, large, boundary, and empty files)
- [x] Conflict test passes with streaming download
- [x] Unit tests updated with `AsyncRead` mock