### PR TITLE
Add docker-compose for deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
               -v /mnt/volume-cloudsync/cloudsync:/data \
               -e CLOUDSYNC_TOKEN=$CLOUDSYNC_TOKEN \
               -e CLOUDSYNC_STORAGE_DIR=/data/files \
+              -e CLOUDSYNC_STAGING_DIR=/data/staging \
               -e CLOUDSYNC_DBNAME=/data/data.redb \
               -e CLOUDSYNC_HOST=0.0.0.0 \
               -e RUST_LOG=cloudsync_server=info \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,19 +40,10 @@ jobs:
           mkdir -p ~/.ssh
           echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
+          scp -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key docker-compose.yml root@46.224.102.7:~/docker-compose.yml
           ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key root@46.224.102.7 << EOF
-            docker pull ghcr.io/devchris123/cloudsync-server:${{ github.ref_name }}
-            docker stop cloudsync-server || true
-            docker rm cloudsync-server || true
-            docker run -d --init --name cloudsync-server \
-              -p 3050:3050 \
-              -v /mnt/volume-cloudsync/cloudsync:/data \
-              -e CLOUDSYNC_TOKEN=$CLOUDSYNC_TOKEN \
-              -e CLOUDSYNC_STORAGE_DIR=/data/files \
-              -e CLOUDSYNC_STAGING_DIR=/data/staging \
-              -e CLOUDSYNC_DBNAME=/data/data.redb \
-              -e CLOUDSYNC_HOST=0.0.0.0 \
-              -e RUST_LOG=cloudsync_server=info \
-              --restart unless-stopped \
-              ghcr.io/devchris123/cloudsync-server:${{ github.ref_name }}
+            CLOUDSYNC_DOCKER_TAG=${{ github.ref_name }} \
+            CLOUDSYNC_MOUNT_DIR=/mnt/volume-cloudsync/cloudsync \
+            CLOUDSYNC_TOKEN=$CLOUDSYNC_TOKEN \
+            docker compose -f ~/docker-compose.yml up -d
           EOF

--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ A self-hosted Dropbox alternative written in Rust. CLI-driven manual sync with c
 
 ### Server
 
+Create a `.env` file:
+
+```
+CLOUDSYNC_TOKEN=your-secret-token
+CLOUDSYNC_MOUNT_DIR=/path/to/data
+```
+
+Then run:
+
 ```sh
-docker run -d \
-  -p 3050:3050 \
-  -v /path/to/data:/data \
-  -e CLOUDSYNC_TOKEN=your-secret-token \
-  -e CLOUDSYNC_STORAGE_DIR=/data/files \
-  -e CLOUDSYNC_STAGING_DIR=/data/staging \
-  -e CLOUDSYNC_DBNAME=/data/data.redb \
-  ghcr.io/devchris123/cloudsync:latest
+docker compose up -d
 ```
 
 ### Client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  cloudsync:
+    image: ghcr.io/devchris123/cloudsync-server:${CLOUDSYNC_DOCKER_TAG:-latest}
+    ports:
+      - "3050:3050"
+    volumes:
+      - ${CLOUDSYNC_MOUNT_DIR}:/data
+    environment:
+      - CLOUDSYNC_TOKEN=$CLOUDSYNC_TOKEN
+      - CLOUDSYNC_STORAGE_DIR=/data/files
+      - CLOUDSYNC_STAGING_DIR=/data/staging
+      - CLOUDSYNC_DBNAME=/data/data.redb
+      - CLOUDSYNC_HOST=0.0.0.0
+      - RUST_LOG=cloudsync_server=info
+    restart: unless-stopped

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,14 +63,14 @@ These are listed in dependency order: large files enables UI upload progress, ea
 
 ### 2.1 Auto-generate auth token on first run
 - Make `--token` / `CLOUDSYNC_TOKEN` optional
-- If no token provided: generate random 256-bit hex token, write to `{storage_dir}/.token`, print to stdout
+- If no token provided: generate random 256-bit hex token, write to `{storage_dir}/.token`, print file path to stdout (avoids token leaking into logs/shell history)
 - On subsequent starts: read from `.token` file if env var not set
 - Add `rand` dependency
 - Files: `crates/cloudsync-server/src/cli.rs`, `crates/cloudsync-server/src/main.rs`
 
 ### 2.2 docker-compose.yml
 - Single service, GHCR image, port 3050, named volume to `/data`
-- No token needed — auto-generates on first run, visible in `docker compose logs`
+- No token needed — auto-generates on first run, admin reads from `.token` file in the volume
 - New file: `docker-compose.yml`
 
 ### 2.3 Improved health endpoint

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -70,9 +70,5 @@ The release workflow (`.github/workflows/release.yml`) handles:
 
 - Building and pushing the Docker image to ghcr.io
 - SSHing into the server
-- Pulling the latest image
-- Running the container with:
-  - Volume: `/mnt/volume-cloudsync/cloudsync:/data`
-  - Port: `3050`
-  - `--init` for signal handling
-  - `--restart unless-stopped` for auto-restart
+- Copying `docker-compose.yml` to the server
+- Running `docker compose up -d` with env vars for image tag, mount dir, and token


### PR DESCRIPTION
Closes #7

## Summary
- Add `docker-compose.yml` with configurable env vars for image tag, mount dir, and token
- Replace manual `docker run` in release workflow with `docker compose up -d`
- Fix missing `CLOUDSYNC_STAGING_DIR` in deployment config

## Test plan
- [ ] Verify release workflow deploys correctly on next tag push
- [ ] Verify `docker compose up -d` works locally with `.env` file