### PR TITLE
Add read-only web UI file browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "askama"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b8246bcbf8eb97abef10c2d92166449680d41d55c0fc6978a91dec2e3619608"
+dependencies = [
+ "askama_macros",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9670bc84a28bb3da91821ef74226949ab63f1265aff7c751634f1dd0e6f97c"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_macros"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0756b45480437dded0565dfc568af62ccce146fb6cfe902e808ba86e445f44f"
+dependencies = [
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0af3691ba3af77949c0b5a3925444b85cb58a0184cc7fec16c68ba2e7be868"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+ "winnow 1.0.1",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,16 +240,25 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -205,9 +275,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -317,15 +387,21 @@ name = "cloudsync-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "askama",
  "axum",
  "chrono",
  "clap",
  "cloudsync-common",
+ "hex",
+ "hmac",
+ "mime_guess",
  "nanoid",
  "redb",
  "reqwest",
+ "rust-embed",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -359,6 +435,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -399,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -513,6 +619,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,15 +679,30 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -620,9 +751,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -634,7 +765,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -815,12 +945,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -855,9 +985,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -879,9 +1009,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1056,12 +1186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1150,7 +1274,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1253,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1264,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1325,10 +1449,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
+name = "rust-embed"
+version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1391,6 +1549,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,9 +1565,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1475,6 +1642,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -1594,18 +1772,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1633,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1648,9 +1826,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -1665,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1729,7 +1907,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1854,6 +2032,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,6 +2098,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1961,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1971,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1981,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1994,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2050,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2070,11 +2264,20 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2142,7 +2345,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2160,14 +2372,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2177,10 +2406,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2189,10 +2430,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2201,10 +2454,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2213,16 +2478,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]

--- a/crates/cloudsync-server/Cargo.toml
+++ b/crates/cloudsync-server/Cargo.toml
@@ -18,6 +18,12 @@ tracing-subscriber = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
 nanoid = "0.4"
+askama = "0.15"
+rust-embed = "8"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+mime_guess = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/cloudsync-server/Cargo.toml
+++ b/crates/cloudsync-server/Cargo.toml
@@ -18,6 +18,7 @@ tracing-subscriber = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
 nanoid = "0.4"
+# Web UI
 askama = "0.15"
 rust-embed = "8"
 hmac = "0.12"

--- a/crates/cloudsync-server/src/app.rs
+++ b/crates/cloudsync-server/src/app.rs
@@ -228,32 +228,46 @@ async fn get_health() -> Result<Json<GetHealthResponse>, AppError> {
     }))
 }
 
-async fn auth_layer(
-    State(state): State<AppState>,
-    request: Request,
-    next: Next,
-) -> Result<Response, StatusCode> {
-    let headers = request.headers();
+#[derive(Clone)]
+struct AuthGranted;
 
-    // Check Bearer token header (CLI / API clients)
-    if let Some(auth_header) = headers.get("Authorization")
+async fn bearer_auth_layer(
+    State(state): State<AppState>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    if let Some(auth_header) = request.headers().get("Authorization")
         && auth_header.to_str().unwrap() == format!("Bearer {}", state.token)
     {
-        tracing::trace!("access granted via bearer token");
-        return Ok(next.run(request).await);
+        tracing::trace!("bearer token valid");
+        request.extensions_mut().insert(AuthGranted);
     }
+    next.run(request).await
+}
 
-    // Check session cookie (browser)
-    if let Some(cookie_header) = headers.get(axum::http::header::COOKIE)
+async fn cookie_auth_layer(
+    State(state): State<AppState>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    if let Some(cookie_header) = request.headers().get(axum::http::header::COOKIE)
         && let Ok(cookie_str) = cookie_header.to_str()
         && crate::ui::verify_session_cookie(cookie_str, &state.token)
     {
-        tracing::trace!("access granted via session cookie");
-        return Ok(next.run(request).await);
+        tracing::trace!("session cookie valid");
+        request.extensions_mut().insert(AuthGranted);
     }
+    next.run(request).await
+}
 
-    tracing::warn!("access denied: no valid authorization");
-    Err(StatusCode::FORBIDDEN)
+async fn require_auth_layer(request: Request, next: Next) -> Result<Response, StatusCode> {
+    if request.extensions().get::<AuthGranted>().is_some() {
+        tracing::trace!("access granted");
+        Ok(next.run(request).await)
+    } else {
+        tracing::warn!("access denied: no valid authorization");
+        Err(StatusCode::FORBIDDEN)
+    }
 }
 
 pub fn create_app(state: AppState) -> Router {
@@ -273,9 +287,14 @@ pub fn create_app(state: AppState) -> Router {
             "/api/v1/uploads/{upload_id}/finalize",
             post(finalize_upload),
         )
+        .route_layer(axum::middleware::from_fn(require_auth_layer))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
-            auth_layer,
+            cookie_auth_layer,
+        ))
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            bearer_auth_layer,
         ))
         .layer(DefaultBodyLimit::max(5 * 1024 * 1024)); // 4MB + overhead
 

--- a/crates/cloudsync-server/src/app.rs
+++ b/crates/cloudsync-server/src/app.rs
@@ -234,20 +234,30 @@ async fn auth_layer(
     next: Next,
 ) -> Result<Response, StatusCode> {
     let headers = request.headers();
-    let auth_header = headers.get("Authorization");
-    let Some(auth_header) = auth_header else {
-        tracing::warn!("access denied: no authorization header");
-        return Err(StatusCode::FORBIDDEN);
-    };
-    if auth_header.to_str().unwrap() != format!("Bearer {}", state.token) {
-        tracing::warn!("access denied: token invalid");
-        return Err(StatusCode::FORBIDDEN);
+
+    // Check Bearer token header (CLI / API clients)
+    if let Some(auth_header) = headers.get("Authorization")
+        && auth_header.to_str().unwrap() == format!("Bearer {}", state.token)
+    {
+        tracing::trace!("access granted via bearer token");
+        return Ok(next.run(request).await);
     }
-    tracing::trace!("access granted");
-    Ok(next.run(request).await)
+
+    // Check session cookie (browser)
+    if let Some(cookie_header) = headers.get(axum::http::header::COOKIE)
+        && let Ok(cookie_str) = cookie_header.to_str()
+        && crate::ui::verify_session_cookie(cookie_str, &state.token)
+    {
+        tracing::trace!("access granted via session cookie");
+        return Ok(next.run(request).await);
+    }
+
+    tracing::warn!("access denied: no valid authorization");
+    Err(StatusCode::FORBIDDEN)
 }
 
 pub fn create_app(state: AppState) -> Router {
+    // API routes with Bearer token / cookie auth
     let auth_router = Router::<AppState>::new()
         .route("/api/v1/files", get(list_files))
         .route("/api/v1/files", post(post_file))
@@ -268,9 +278,22 @@ pub fn create_app(state: AppState) -> Router {
             auth_layer,
         ))
         .layer(DefaultBodyLimit::max(5 * 1024 * 1024)); // 4MB + overhead
+
+    // Web UI routes (auth handled per-handler via cookie check)
+    let ui_router = Router::<AppState>::new()
+        .route("/", get(crate::ui::index))
+        .route(
+            "/login",
+            get(crate::ui::login_page).post(crate::ui::login_submit),
+        )
+        .route("/logout", post(crate::ui::logout))
+        .route("/browse", get(crate::ui::browse))
+        .route("/static/{*path}", get(crate::ui::static_file));
+
     Router::<AppState>::new()
         .route("/api/v1/health", get(get_health))
         .merge(auth_router)
+        .merge(ui_router)
         .layer(TraceLayer::new_for_http())
         .layer(DefaultBodyLimit::max(50 * 1024 * 1024)) // 50MB
         .with_state(state)

--- a/crates/cloudsync-server/src/lib.rs
+++ b/crates/cloudsync-server/src/lib.rs
@@ -3,3 +3,4 @@ pub mod config;
 mod db;
 mod db_upload;
 mod storage;
+mod ui;

--- a/crates/cloudsync-server/src/ui.rs
+++ b/crates/cloudsync-server/src/ui.rs
@@ -1,0 +1,331 @@
+use std::collections::BTreeSet;
+
+use askama::Template;
+use axum::{
+    extract::{Query, State},
+    http::{HeaderValue, StatusCode, header},
+    response::{Html, IntoResponse, Redirect, Response},
+};
+use cloudsync_common::FileMeta;
+use hmac::{Hmac, Mac};
+use rust_embed::RustEmbed;
+use sha2::Sha256;
+
+use crate::app::AppState;
+use crate::db;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const COOKIE_NAME: &str = "cloudsync_session";
+
+#[derive(RustEmbed)]
+#[folder = "static/"]
+struct StaticAssets;
+
+// --- Templates ---
+
+#[derive(Template)]
+#[template(path = "login.html")]
+struct LoginTemplate {
+    error: String,
+}
+
+pub struct Breadcrumb {
+    pub name: String,
+    pub prefix: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct FileEntry {
+    pub path: String,
+    pub name: String,
+    pub display_size: String,
+    pub display_date: String,
+}
+
+#[derive(Template)]
+#[template(path = "browser.html")]
+struct BrowserTemplate {
+    prefix: String,
+    breadcrumbs: Vec<Breadcrumb>,
+    directories: Vec<String>,
+    files: Vec<FileEntry>,
+}
+
+// --- Cookie auth helpers ---
+
+fn sign_token(token: &str) -> String {
+    let mut mac =
+        HmacSha256::new_from_slice(token.as_bytes()).expect("HMAC can take key of any size");
+    mac.update(b"cloudsync_session");
+    hex::encode(mac.finalize().into_bytes())
+}
+
+fn make_session_cookie(token: &str) -> String {
+    let sig = sign_token(token);
+    format!("{COOKIE_NAME}={sig}; HttpOnly; SameSite=Strict; Path=/")
+}
+
+fn clear_session_cookie() -> String {
+    format!("{COOKIE_NAME}=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0")
+}
+
+pub fn verify_session_cookie(cookie_header: &str, token: &str) -> bool {
+    let expected = sign_token(token);
+    for part in cookie_header.split(';') {
+        let part = part.trim();
+        if let Some(value) = part.strip_prefix(&format!("{COOKIE_NAME}=")) {
+            return value == expected;
+        }
+    }
+    false
+}
+
+// --- Helpers ---
+
+fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+fn build_breadcrumbs(prefix: &str) -> Vec<Breadcrumb> {
+    let mut crumbs = Vec::new();
+    let mut accumulated = String::new();
+    for segment in prefix.split('/').filter(|s| !s.is_empty()) {
+        accumulated.push_str(segment);
+        accumulated.push('/');
+        crumbs.push(Breadcrumb {
+            name: segment.to_string(),
+            prefix: accumulated.clone(),
+        });
+    }
+    crumbs
+}
+
+fn has_session(headers: &axum::http::HeaderMap, token: &str) -> bool {
+    headers
+        .get(header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|cookie| verify_session_cookie(cookie, token))
+}
+
+// --- Handlers ---
+
+#[derive(serde::Deserialize)]
+pub struct BrowseQuery {
+    pub prefix: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+pub struct LoginForm {
+    pub token: String,
+}
+
+pub async fn index(State(state): State<AppState>, headers: axum::http::HeaderMap) -> Response {
+    if has_session(&headers, &state.token) {
+        Redirect::to("/browse").into_response()
+    } else {
+        Redirect::to("/login").into_response()
+    }
+}
+
+pub async fn login_page(State(state): State<AppState>, headers: axum::http::HeaderMap) -> Response {
+    if has_session(&headers, &state.token) {
+        return Redirect::to("/browse").into_response();
+    }
+    let template = LoginTemplate {
+        error: String::new(),
+    };
+    Html(template.render().unwrap()).into_response()
+}
+
+pub async fn login_submit(
+    State(state): State<AppState>,
+    axum::Form(form): axum::Form<LoginForm>,
+) -> Response {
+    if form.token != state.token {
+        let template = LoginTemplate {
+            error: "Invalid token.".to_string(),
+        };
+        return (StatusCode::FORBIDDEN, Html(template.render().unwrap())).into_response();
+    }
+    let cookie = make_session_cookie(&state.token);
+    let mut response = Redirect::to("/browse").into_response();
+    response
+        .headers_mut()
+        .insert(header::SET_COOKIE, HeaderValue::from_str(&cookie).unwrap());
+    response
+}
+
+pub async fn logout() -> Response {
+    let cookie = clear_session_cookie();
+    let mut response = Redirect::to("/login").into_response();
+    response
+        .headers_mut()
+        .insert(header::SET_COOKIE, HeaderValue::from_str(&cookie).unwrap());
+    response
+}
+
+pub async fn browse(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    Query(query): Query<BrowseQuery>,
+) -> Response {
+    if !has_session(&headers, &state.token) {
+        return Redirect::to("/login").into_response();
+    }
+
+    let prefix = query.prefix.unwrap_or_default();
+    let all_files = match db::list(&state.db) {
+        Ok(f) => f,
+        Err(_) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Failed to list files").into_response();
+        }
+    };
+
+    let (files, directories) = files_and_dirs(all_files, &prefix);
+
+    let template = BrowserTemplate {
+        breadcrumbs: build_breadcrumbs(&prefix),
+        prefix,
+        directories: directories.into_iter().collect(),
+        files,
+    };
+
+    Html(template.render().unwrap()).into_response()
+}
+
+fn files_and_dirs(all_files: Vec<FileMeta>, prefix: &str) -> (Vec<FileEntry>, BTreeSet<String>) {
+    // Derive directories and files at the current prefix level
+    let mut directories = BTreeSet::new();
+    let mut files = Vec::new();
+
+    for file_meta in &all_files {
+        let Some(relative) = file_meta.path.strip_prefix(prefix) else {
+            continue;
+        };
+        if let Some(slash_pos) = relative.find('/') {
+            // This file is in a subdirectory
+            let dir_name = &relative[..=slash_pos];
+            directories.insert(dir_name.to_string());
+        } else {
+            // This file is at the current level
+            files.push(FileEntry {
+                path: file_meta.path.clone(),
+                name: relative.to_string(),
+                display_size: format_size(file_meta.size),
+                display_date: file_meta.modified_at.format("%Y-%m-%d %H:%M").to_string(),
+            });
+        }
+    }
+    (files, directories)
+}
+
+pub async fn static_file(axum::extract::Path(path): axum::extract::Path<String>) -> Response {
+    let Some(file) = StaticAssets::get(&path) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let mime = mime_guess::from_path(&path).first_or_octet_stream();
+    ([(header::CONTENT_TYPE, mime.as_ref())], file.data.to_vec()).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::ui::{sign_token, verify_session_cookie};
+
+    #[test]
+    fn test_sign_token_consistent() {
+        let token = "token";
+
+        assert_eq!(sign_token(token), sign_token(token));
+    }
+
+    #[test]
+    fn test_verify_session_cookie_succeeds() {
+        let signed_token = sign_token("sometoken");
+        let cookie_header = format!("{COOKIE_NAME}={signed_token}");
+
+        let result = verify_session_cookie(cookie_header.as_str(), "sometoken");
+
+        assert!(result);
+    }
+
+    #[test]
+    fn test_verify_session_cookie_fails() {
+        let cookie_header = format!("{COOKIE_NAME}=falsetokenhash");
+
+        let result = verify_session_cookie(cookie_header.as_str(), "sometoken");
+
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_verify_session_cookie_missing_cookie_fails() {
+        let cookie_header = "";
+
+        let result = verify_session_cookie(cookie_header, "sometoken");
+
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_browse() {
+        let all_files = vec![
+            create_file_meta("file0".to_string()),
+            create_file_meta("file1".to_string()),
+            create_file_meta("subdir/file0".to_string()),
+            create_file_meta("subdir/file1".to_string()),
+        ];
+        let prefix = "";
+        let expected_files = vec![
+            FileEntry {
+                path: "file0".to_string(),
+                name: "file0".to_string(),
+                display_size: format_size(0),
+                display_date: all_files[0]
+                    .modified_at
+                    .format("%Y-%m-%d %H:%M")
+                    .to_string(),
+            },
+            FileEntry {
+                path: "file1".to_string(),
+                name: "file1".to_string(),
+                display_size: format_size(0),
+                display_date: all_files[1]
+                    .modified_at
+                    .format("%Y-%m-%d %H:%M")
+                    .to_string(),
+            },
+        ];
+        let expected_dirs = BTreeSet::from(["subdir/".to_string()]);
+
+        let (files, dirs) = files_and_dirs(all_files, prefix);
+
+        assert_eq!(files, expected_files);
+        assert_eq!(dirs, expected_dirs);
+    }
+
+    fn create_file_meta(path: String) -> FileMeta {
+        FileMeta {
+            path,
+            size: 0,
+            content_hash: "".to_string(),
+            version: 0,
+            is_deleted: false,
+            created_at: chrono::Utc::now(),
+            modified_at: chrono::Utc::now(),
+        }
+    }
+}

--- a/crates/cloudsync-server/static/style.css
+++ b/crates/cloudsync-server/static/style.css
@@ -1,0 +1,198 @@
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+:root {
+    --bg: #fafafa;
+    --fg: #1a1a1a;
+    --muted: #666;
+    --border: #ddd;
+    --accent: #2563eb;
+    --accent-hover: #1d4ed8;
+    --surface: #fff;
+    --radius: 6px;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+    line-height: 1.5;
+}
+
+/* Nav */
+nav {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 0.75rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+nav .brand {
+    font-weight: 700;
+    font-size: 1.1rem;
+}
+
+nav form button {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.3rem 0.8rem;
+    cursor: pointer;
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+nav form button:hover {
+    border-color: var(--fg);
+    color: var(--fg);
+}
+
+/* Main */
+main {
+    max-width: 960px;
+    margin: 2rem auto;
+    padding: 0 1.5rem;
+}
+
+/* Breadcrumbs */
+.breadcrumbs {
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    color: var(--muted);
+}
+
+.breadcrumbs a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.breadcrumbs a:hover {
+    text-decoration: underline;
+}
+
+.breadcrumbs .sep {
+    margin: 0 0.3rem;
+}
+
+/* File table */
+.file-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.file-table th,
+.file-table td {
+    text-align: left;
+    padding: 0.6rem 1rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.file-table th {
+    background: var(--bg);
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.file-table tr:last-child td {
+    border-bottom: none;
+}
+
+.file-table a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.file-table a:hover {
+    text-decoration: underline;
+}
+
+.file-table .size,
+.file-table .date {
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.file-table .icon {
+    margin-right: 0.4rem;
+}
+
+/* Login */
+.login-card {
+    max-width: 380px;
+    margin: 6rem auto;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 2rem;
+}
+
+.login-card h1 {
+    font-size: 1.3rem;
+    margin-bottom: 1.5rem;
+}
+
+.login-card label {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin-bottom: 0.3rem;
+    color: var(--muted);
+}
+
+.login-card input[type="password"] {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 0.95rem;
+    margin-bottom: 1rem;
+}
+
+.login-card input[type="password"]:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+    border-color: var(--accent);
+}
+
+.login-card button {
+    width: 100%;
+    padding: 0.55rem;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: var(--radius);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.login-card button:hover {
+    background: var(--accent-hover);
+}
+
+.login-card .error {
+    color: #dc2626;
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+}
+
+/* Empty state */
+.empty {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--muted);
+}

--- a/crates/cloudsync-server/templates/base.html
+++ b/crates/cloudsync-server/templates/base.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}CloudSync{% endblock %}</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    {% block body %}{% endblock %}
+</body>
+</html>

--- a/crates/cloudsync-server/templates/browser.html
+++ b/crates/cloudsync-server/templates/browser.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block title %}Browse — CloudSync{% endblock %}
+
+{% block body %}
+<nav>
+    <span class="brand">CloudSync</span>
+    <form method="post" action="/logout">
+        <button type="submit">Sign out</button>
+    </form>
+</nav>
+<main>
+    <div class="breadcrumbs">
+        <a href="/browse">/</a>
+        {% for crumb in breadcrumbs %}
+        <span class="sep">/</span>
+        <a href="/browse?prefix={{ crumb.prefix }}">{{ crumb.name }}</a>
+        {% endfor %}
+    </div>
+
+    {% if directories.is_empty() && files.is_empty() %}
+    <div class="empty">
+        <p>No files here.</p>
+    </div>
+    {% else %}
+    <table class="file-table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Size</th>
+                <th>Modified</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for dir in directories %}
+            <tr>
+                <td><span class="icon">&#128193;</span><a href="/browse?prefix={{ prefix }}{{ dir }}">{{ dir }}</a></td>
+                <td class="size">—</td>
+                <td class="date">—</td>
+            </tr>
+            {% endfor %}
+            {% for file in files %}
+            <tr>
+                <td><a href="/api/v1/files/{{ file.path }}">{{ file.name }}</a></td>
+                <td class="size">{{ file.display_size }}</td>
+                <td class="date">{{ file.display_date }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+</main>
+{% endblock %}

--- a/crates/cloudsync-server/templates/login.html
+++ b/crates/cloudsync-server/templates/login.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}Login — CloudSync{% endblock %}
+
+{% block body %}
+<div class="login-card">
+    <h1>CloudSync</h1>
+    {% if !error.is_empty() %}
+    <p class="error">{{ error }}</p>
+    {% endif %}
+    <form method="post" action="/login">
+        <label for="token">Access Token</label>
+        <input type="password" id="token" name="token" placeholder="Enter your bearer token" required autofocus>
+        <button type="submit">Sign in</button>
+    </form>
+</div>
+{% endblock %}

--- a/docs/plan-web-ui.md
+++ b/docs/plan-web-ui.md
@@ -1,0 +1,142 @@
+# Phase 3: Web UI — Read-Only File Browser
+
+## Context
+
+CloudSync is CLI-only today. Phase 3 adds a Web UI. We start with a **read-only file browser** — login, browse directories, view file metadata, download files. Upload and delete come later as incremental additions once the foundation is solid.
+
+## Approach: Askama + Vanilla CSS (instead of React + Vite)
+
+The roadmap proposed React + TypeScript + Vite embedded via `rust-embed`. After analysis, **Askama server-rendered templates** are a better fit for the read-only scope:
+
+| Criteria | React + Vite | Askama + CSS |
+|----------|-------------|--------------|
+| Build dependencies | Adds Node.js to CI + Docker | Zero change — pure `cargo build` |
+| Tooling overhead | ~200MB node_modules, package.json, vite.config, tsconfig | None |
+| JavaScript needed | Yes (SPA) | None for read-only scope |
+| Single-binary deploy | Yes (via rust-embed) | Yes (via rust-embed) |
+| Proportionality | ~500 lines UI code for file browser | ~150 lines Rust + 3 HTML templates |
+| Future upgrades | Already set up for richer UI | Add vanilla JS incrementally for upload/delete |
+
+React makes sense if the UI grows into a full dashboard. For a file browser with download links, server-rendered HTML is the right tool.
+
+---
+
+## Implementation Steps
+
+### Step 1: Dependencies and module structure
+
+Add to `crates/cloudsync-server/Cargo.toml`:
+- `askama = "0.13"` — compile-time HTML templates
+- `askama_axum = "0.5"` — Axum responder integration
+- `rust-embed = "8"` — embed static assets (CSS) into binary
+
+Create files:
+```
+crates/cloudsync-server/
+  templates/
+    base.html           — layout shell (head, nav, CSS link)
+    login.html          — token input form
+    browser.html        — file table + breadcrumbs
+  static/
+    style.css           — minimal CSS
+  src/
+    ui.rs               — UI route handlers + RustEmbed struct
+```
+
+Wire `mod ui;` in `src/lib.rs`.
+
+### Step 2: Prefix filtering on file listing
+
+Modify `db::list()` in `src/db.rs` to accept an optional prefix parameter. Derive a directory listing from the flat file paths:
+- Immediate subdirectories at the current prefix level
+- Files at the current prefix level (not nested deeper)
+
+Example: with files `a.txt`, `photos/1.jpg`, `photos/vacation/2.jpg` and prefix `photos/`:
+- Directories: `["vacation/"]`
+- Files: `[FileMeta for "photos/1.jpg"]`
+
+Expose on the API too: `GET /api/v1/files?prefix=photos/` — benefits future API clients.
+
+**Files:** `crates/cloudsync-server/src/db.rs`, `crates/cloudsync-server/src/app.rs`
+
+### Step 3: Cookie-based auth for browser sessions
+
+Extend `auth_layer` in `app.rs` to accept either:
+- `Authorization: Bearer <token>` header (existing — CLI and API clients)
+- A signed `HttpOnly; SameSite=Strict` auth cookie (new — browser sessions)
+
+Add handlers:
+- `POST /login` — validate token, set cookie, redirect to `/browse`
+- `POST /logout` — clear cookie, redirect to `/login`
+
+The cookie contains an HMAC signature derived from the token, enabling stateless verification without a session store.
+
+**Files:** `crates/cloudsync-server/src/app.rs`, `crates/cloudsync-server/src/ui.rs`
+
+### Step 4: Templates and UI routes
+
+**Templates (Askama):**
+- `base.html` — HTML5 shell, embedded CSS link, nav bar with "CloudSync" title
+- `login.html` — extends base, single text field for bearer token, POST form
+- `browser.html` — extends base, breadcrumb nav (prefix split on `/`), table with columns: name, size, modified date. Directories link deeper (`/browse?prefix=dir/`). Files have download links.
+
+**Routes:**
+- `GET /` — redirect to `/browse` (if auth cookie present) or `/login`
+- `GET /login` — render login page
+- `GET /browse?prefix=` — render file browser (requires auth cookie)
+- `GET /static/{*path}` — serve embedded CSS
+- `POST /login` — validate + set cookie
+- `POST /logout` — clear cookie
+
+**Files:** `crates/cloudsync-server/src/ui.rs`, `templates/`, `static/`
+
+### Step 5: File downloads from browser
+
+Each file row in the browser template links to `/api/v1/files/{path}`. Since `auth_layer` now accepts cookies (Step 3), the browser sends the auth cookie automatically and the file streams down — no JavaScript needed.
+
+**No new code** — this works from the template links + auth middleware change.
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `crates/cloudsync-server/Cargo.toml` | Add askama, askama_axum, rust-embed |
+| `crates/cloudsync-server/src/lib.rs` | Add `mod ui;` |
+| `crates/cloudsync-server/src/app.rs` | Add UI routes, extend auth_layer for cookies |
+| `crates/cloudsync-server/src/db.rs` | Add optional prefix filtering to `list()` |
+| `crates/cloudsync-server/src/ui.rs` | **New** — UI handlers, RustEmbed struct, template structs |
+| `crates/cloudsync-server/templates/*.html` | **New** — 3 Askama templates |
+| `crates/cloudsync-server/static/style.css` | **New** — minimal CSS |
+
+## Unchanged
+
+- **Dockerfile** — no new build stages needed
+- **CI** — no new steps
+- **cloudsync-common** — shared types unchanged
+- **cloudsync-client** — CLI unaffected
+- **Existing API** — fully backward compatible
+
+---
+
+## Verification
+
+1. `cargo build` — compiles with templates + CSS embedded
+2. `cargo test` — existing tests still pass
+3. `cargo clippy -- --deny warnings` — no new warnings
+4. Start server: `cargo run -- --token test123`
+5. Open `http://localhost:3050/` — redirects to `/login`
+6. Enter token — redirects to `/browse`
+7. File browser shows files with name, size, date
+8. Click a directory — breadcrumb updates, shows nested contents
+9. Click a file — browser downloads it
+10. CLI `push`/`pull` still works (API unchanged)
+
+---
+
+## Future Increments (not in scope)
+
+- **Upload**: drag-and-drop + file picker, chunked upload with progress bar (vanilla JS)
+- **Delete**: per-file button with confirmation dialog (vanilla JS)
+- **Dashboard**: file count, storage usage, server uptime


### PR DESCRIPTION
## Summary

- Add server-rendered web UI for browsing and downloading files (closes #10)
- Uses Askama templates + embedded CSS via rust-embed — no Node.js/React dependency
- Cookie-based auth (HMAC-signed) for browser sessions, alongside existing Bearer token for CLI
- File downloads work natively via the auth cookie — zero JavaScript needed

## Approach

Chose Askama over the roadmap's React+Vite proposal because the read-only scope doesn't need JS, and this keeps CI/Docker/build as pure `cargo build`. See `docs/plan-web-ui.md` for the full rationale.

## Routes added

- `GET /` — redirect to `/browse` or `/login`
- `GET /login` / `POST /login` — token login
- `POST /logout` — clear session
- `GET /browse?prefix=` — file browser with breadcrumb navigation
- `GET /static/*` — embedded CSS

## Test plan

- [ ] `cargo build && cargo test && cargo clippy -- --deny warnings && cargo fmt --check`
- [ ] Start server, open `http://localhost:3050/`, verify redirect to `/login`
- [ ] Login with token, verify redirect to `/browse`
- [ ] Browse directories via breadcrumbs, verify file listing
- [ ] Click file to download, verify content
- [ ] CLI `push`/`pull` still works (API backward compatible)