### PR TITLE
Fix release binary rename collision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,10 @@ jobs:
         run: |
           for dir in artifacts/cloudsync-*; do
             name=$(basename "$dir")
-            binary=$(ls "$dir")
-            mv "$dir/$binary" "artifacts/$name"
-            rmdir "$dir"
+            binary=$(find "$dir" -type f | head -1)
+            mv "$binary" "artifacts/${name}.tmp"
+            rm -r "$dir"
+            mv "artifacts/${name}.tmp" "artifacts/${name}"
           done
       - name: Create release
         env:


### PR DESCRIPTION
## Summary

- Fix `mv` failing in the release workflow's rename step
- `mv file dir` moves the file *into* the directory instead of replacing it — use a `.tmp` intermediate name to avoid the collision

## Test plan

- [ ] Merge and tag a new release — verify the rename step succeeds and binaries are attached to the GitHub release