### PR TITLE
Implement resumable chunked uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "cloudsync-common",
  "cloudsync-server",
  "futures",
+ "indicatif",
  "redb",
  "reqwest",
  "serde",
@@ -415,6 +416,18 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -477,6 +490,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -956,6 +975,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1216,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2050,10 +2088,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/crates/cloudsync-client/Cargo.toml
+++ b/crates/cloudsync-client/Cargo.toml
@@ -17,6 +17,7 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 futures = "0.3"
+indicatif = "0.18"
 
 [dev-dependencies]
 cloudsync-server = { path = "../cloudsync-server" }

--- a/crates/cloudsync-client/src/db.rs
+++ b/crates/cloudsync-client/src/db.rs
@@ -34,7 +34,7 @@ pub fn list(db: &Database) -> anyhow::Result<Vec<SyncRecord>> {
     Ok(records)
 }
 
-pub fn put(db: &Database, sync_record: SyncRecord) -> anyhow::Result<()> {
+pub fn put(db: &Database, sync_record: &SyncRecord) -> anyhow::Result<()> {
     let tx = db.begin_write()?;
     {
         let mut table = tx.open_table(TABLE)?;

--- a/crates/cloudsync-client/src/main.rs
+++ b/crates/cloudsync-client/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use redb::Database;
 
 use crate::config::ClientConfig;
@@ -24,7 +25,15 @@ async fn main() -> anyhow::Result<()> {
         }
         cli::Command::Push => {
             let (db, sync_client, sync_root) = setup().await?;
-            sync::push(&db, &sync_client, &sync_root).await?;
+            let mp = MultiProgress::new();
+            let on_file_start = |path: &str, count: u64, completed: u64| -> Box<dyn Fn()> {
+                let pb = mp.add(ProgressBar::new(count));
+                pb.set_position(completed);
+                pb.set_style(ProgressStyle::with_template("{msg} [{bar:20}] {pos}/{len}").unwrap());
+                pb.set_message(path.to_string());
+                Box::new(move || pb.inc(1))
+            };
+            sync::push(&db, &sync_client, &sync_root, &on_file_start).await?;
         }
         cli::Command::Pull => {
             let (db, sync_client, sync_root) = setup().await?;

--- a/crates/cloudsync-client/src/sync.rs
+++ b/crates/cloudsync-client/src/sync.rs
@@ -199,15 +199,37 @@ pub async fn resume_upload(
     }
 
     let mut file = std::fs::File::open(local_path)?;
+    let batch_size: usize = std::env::var("CLOUDSYNC_BATCH_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5);
+    let mut join_set = vec![];
+
     let chunks_received: std::collections::HashSet<u32> = chunks_received.into_iter().collect();
-    for i in 0..chunk_count {
+    for idx in 0..chunk_count {
         let mut buf = Vec::new();
         (&mut file).take(CHUNK_SIZE).read_to_end(&mut buf)?;
-        if chunks_received.contains(&(i as u32)) {
+        // Do the skip after reading file, so the file pointer correctly advances for the next read.
+        if chunks_received.contains(&(idx as u32)) {
             continue;
         }
-        sync_client.send_chunk(&upload_id, i as u32, buf).await?;
+        let fut = sync_client.send_chunk(&upload_id, idx as u32, buf);
+        join_set.push(fut);
+        if join_set.len() == batch_size {
+            let results = futures::future::join_all(join_set.drain(..)).await;
+            for res in results {
+                res?;
+            }
+        }
     }
+    // Final flush in case we skipped the last chunk before the loop ends
+    if !join_set.is_empty() {
+        let results = futures::future::join_all(join_set.drain(..)).await;
+        for res in results {
+            res?;
+        }
+    }
+
     let resp = sync_client.finalize_upload(&upload_id).await?;
     let sync_record = SyncRecord {
         path: rel_path.clone(),

--- a/crates/cloudsync-client/src/sync.rs
+++ b/crates/cloudsync-client/src/sync.rs
@@ -37,6 +37,7 @@ pub struct SyncRecord {
     pub path: String,
     pub local_hash: String,
     pub server_version: u64,
+    pub upload_id: Option<String>,
 }
 
 pub async fn push(
@@ -106,8 +107,9 @@ async fn push_single_file(
         path: rel_path.clone(),
         local_hash: hash,
         server_version: resp.file.version,
+        upload_id: None,
     };
-    db::put(db, sync_record)?;
+    db::put(db, &sync_record)?;
     println!("pushed: {}", &rel_path);
     Ok(())
 }
@@ -126,35 +128,94 @@ pub async fn push_single_file_chunked(
         .to_str()
         .unwrap()
         .to_string();
-    let sync_record = db::get(db, &rel_path)?;
-    if let Some(sr) = sync_record
+    let mut sync_record = db::get(db, &rel_path)?;
+    if let Some(sr) = &sync_record
         && sr.local_hash == hash
     {
         return Ok(());
     }
-    let upload = sync_client
-        .init_upload(InitUploadRequest {
+    let mut upload_id: Option<String> = None;
+    let mut chunks_received: Vec<u32> = vec![];
+    let mut chunk_count = chunk_count;
+
+    if let Some(sr) = &mut sync_record
+        && let Some(id) = sr.upload_id.as_deref()
+    {
+        let result = sync_client.get_upload(id).await;
+        if let Ok(res) = result {
+            upload_id = Some(res.upload.upload_id);
+            chunks_received = res.upload.chunks_received;
+            chunk_count = res.upload.chunk_count;
+        }
+    }
+    if upload_id.is_none() {
+        let upload = sync_client
+            .init_upload(InitUploadRequest {
+                path: rel_path.clone(),
+                total_size,
+                total_hash: hash.clone(),
+                chunk_count,
+            })
+            .await?;
+        upload_id = Some(upload.upload_id);
+    }
+
+    resume_upload(
+        &upload_id.unwrap(),
+        db,
+        sync_client,
+        sync_record.as_mut(),
+        local_path,
+        chunks_received,
+        chunk_count,
+        rel_path,
+        hash,
+    )
+    .await
+}
+
+pub async fn resume_upload(
+    upload_id: &str,
+    db: &Database,
+    sync_client: &impl SyncApi,
+    mut sync_record: Option<&mut SyncRecord>,
+    local_path: &Path,
+    chunks_received: Vec<u32>,
+    chunk_count: u64,
+    rel_path: String,
+    hash: String,
+) -> anyhow::Result<()> {
+    if let Some(sr) = &mut sync_record {
+        sr.upload_id = Some(upload_id.to_string());
+        db::put(db, &sr)?;
+    } else {
+        let sr = SyncRecord {
             path: rel_path.clone(),
-            total_size,
-            total_hash: hash.clone(),
-            chunk_count,
-        })
-        .await?;
+            local_hash: hash.clone(),
+            server_version: 0,
+            upload_id: Some(upload_id.to_string()),
+        };
+        db::put(db, &sr)?;
+    }
+
     let mut file = std::fs::File::open(local_path)?;
+    let chunks_received: std::collections::HashSet<u32> = chunks_received.into_iter().collect();
     for i in 0..chunk_count {
         let mut buf = Vec::new();
         (&mut file).take(CHUNK_SIZE).read_to_end(&mut buf)?;
-        sync_client
-            .send_chunk(&upload.upload_id, i as u32, buf)
-            .await?;
+        if chunks_received.contains(&(i as u32)) {
+            continue;
+        }
+        sync_client.send_chunk(&upload_id, i as u32, buf).await?;
     }
-    let resp = sync_client.finalize_upload(&upload.upload_id).await?;
+    let resp = sync_client.finalize_upload(&upload_id).await?;
     let sync_record = SyncRecord {
         path: rel_path.clone(),
         local_hash: hash,
         server_version: resp.file.version,
+        upload_id: None,
     };
-    db::put(db, sync_record)?;
+    db::put(db, &sync_record)?;
     println!("pushed: {}", &rel_path);
     Ok(())
 }
@@ -235,8 +296,9 @@ async fn pull_single_file(
         path: file_meta.path.clone(),
         local_hash: hash_file(local_path)?,
         server_version: file_meta.version,
+        upload_id: None,
     };
-    db::put(db, sync_record)?;
+    db::put(db, &sync_record)?;
     println!("pulled: {}", &file_meta.path);
 
     Ok(())
@@ -322,7 +384,11 @@ mod tests {
         delete_count: RefCell<u64>,
         init_upload_count: RefCell<u64>,
         send_chunk_count: RefCell<u64>,
+        send_chunk_fails: RefCell<bool>,
         get_upload_count: RefCell<u64>,
+        get_upload_chunks_received: RefCell<Vec<u32>>,
+        get_upload_chunk_count: RefCell<u64>,
+        get_upload_fail_id: RefCell<Option<String>>,
         finalize_upload_count: RefCell<u64>,
         fail_path: RefCell<Option<String>>,
     }
@@ -337,7 +403,11 @@ mod tests {
                 delete_count: RefCell::new(0),
                 init_upload_count: RefCell::new(0),
                 send_chunk_count: RefCell::new(0),
+                send_chunk_fails: RefCell::new(false),
                 get_upload_count: RefCell::new(0),
+                get_upload_chunks_received: RefCell::new(vec![]),
+                get_upload_chunk_count: RefCell::new(0),
+                get_upload_fail_id: RefCell::new(None),
                 finalize_upload_count: RefCell::new(0),
                 fail_path: RefCell::new(None),
             }
@@ -349,6 +419,22 @@ mod tests {
 
         fn set_fail_path(&self, path: String) {
             *self.fail_path.borrow_mut() = Some(path);
+        }
+
+        fn set_send_chunk_fails(&self, fails: bool) {
+            *self.send_chunk_fails.borrow_mut() = fails;
+        }
+
+        fn set_upload_chunks_received(&self, chunks: Vec<u32>) {
+            *self.get_upload_chunks_received.borrow_mut() = chunks;
+        }
+
+        fn set_upload_chunk_count(&self, chunk_count: u64) {
+            *self.get_upload_chunk_count.borrow_mut() = chunk_count;
+        }
+
+        fn set_upload_fail_id(&self, upload_id: String) {
+            *self.get_upload_fail_id.borrow_mut() = Some(upload_id);
         }
     }
 
@@ -408,19 +494,25 @@ mod tests {
             _content: Vec<u8>,
         ) -> anyhow::Result<()> {
             *self.send_chunk_count.borrow_mut() += 1;
+            if *self.send_chunk_fails.borrow() {
+                anyhow::bail!("error sending chunks");
+            }
             Ok(())
         }
 
-        async fn get_upload(&self, _upload_id: &str) -> anyhow::Result<GetUploadResponse> {
+        async fn get_upload(&self, upload_id: &str) -> anyhow::Result<GetUploadResponse> {
             *self.get_upload_count.borrow_mut() += 1;
+            if self.get_upload_fail_id.borrow().as_deref() == Some(upload_id) {
+                anyhow::bail!("error");
+            }
             Ok(GetUploadResponse {
                 upload: Upload {
                     path: "".to_string(),
                     total_size: 10,
                     upload_id: "".to_string(),
                     total_hash: "".to_string(),
-                    chunk_count: 1,
-                    chunks_received: Vec::new(),
+                    chunk_count: *self.get_upload_chunk_count.borrow(),
+                    chunks_received: (*self.get_upload_chunks_received.borrow()).clone(),
                     created_at: Utc::now(),
                     modified_at: Utc::now(),
                 },
@@ -483,9 +575,84 @@ mod tests {
 
         let record = db::get(&db, "file0").unwrap();
         assert!(record.is_some());
+        assert!(record.unwrap().upload_id.is_none());
         assert_eq!(*mock_client.init_upload_count.borrow(), 1);
         assert_eq!(*mock_client.send_chunk_count.borrow(), 3);
         assert_eq!(*mock_client.finalize_upload_count.borrow(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_push_single_file_chunked_resumes() {
+        let (db, mock_client, temp_dir) = setup();
+        let file = temp_dir.path().join("file0");
+        let bytes = b"hello world";
+        std::fs::write(&file, &bytes).unwrap();
+        let sync_record = SyncRecord {
+            path: "file0".to_string(),
+            local_hash: "something".to_string(),
+            server_version: 0,
+            upload_id: Some("test_upload".to_string()),
+        };
+        db::put(&db, &sync_record).unwrap();
+        mock_client.set_upload_chunks_received(vec![1, 3, 4]);
+        mock_client.set_upload_chunk_count(5);
+
+        push_single_file_chunked(&db, &mock_client, temp_dir.path(), &file)
+            .await
+            .unwrap();
+
+        let record = db::get(&db, "file0").unwrap();
+        assert!(record.is_some());
+        assert!(record.unwrap().upload_id.is_none());
+        assert_eq!(*mock_client.init_upload_count.borrow(), 0);
+        assert_eq!(*mock_client.send_chunk_count.borrow(), 2);
+        assert_eq!(*mock_client.finalize_upload_count.borrow(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_push_single_file_chunked_expired() {
+        let (db, mock_client, temp_dir) = setup();
+        let file = temp_dir.path().join("file0");
+        let bytes = b"hello world";
+        std::fs::write(&file, &bytes).unwrap();
+        let sync_record = SyncRecord {
+            path: "file0".to_string(),
+            local_hash: "something".to_string(),
+            server_version: 0,
+            upload_id: Some("test_upload".to_string()),
+        };
+        db::put(&db, &sync_record).unwrap();
+        mock_client.set_upload_fail_id("test_upload".to_string());
+
+        push_single_file_chunked(&db, &mock_client, temp_dir.path(), &file)
+            .await
+            .unwrap();
+
+        let record = db::get(&db, "file0").unwrap();
+        assert!(record.is_some());
+        assert!(record.unwrap().upload_id.is_none());
+        assert_eq!(*mock_client.init_upload_count.borrow(), 1);
+        assert_eq!(*mock_client.send_chunk_count.borrow(), 1);
+        assert_eq!(*mock_client.finalize_upload_count.borrow(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_push_single_file_chunked_crashes() {
+        let (db, mock_client, temp_dir) = setup();
+        let file = temp_dir.path().join("file0");
+        let bytes = b"hello world";
+        std::fs::write(&file, &bytes).unwrap();
+        mock_client.set_send_chunk_fails(true);
+
+        let result = push_single_file_chunked(&db, &mock_client, temp_dir.path(), &file).await;
+
+        let record = db::get(&db, "file0").unwrap();
+        assert!(result.is_err());
+        assert!(record.is_some());
+        assert!(record.unwrap().upload_id.is_some());
+        assert_eq!(*mock_client.init_upload_count.borrow(), 1);
+        assert_eq!(*mock_client.send_chunk_count.borrow(), 1);
+        assert_eq!(*mock_client.finalize_upload_count.borrow(), 0);
     }
 
     #[tokio::test]
@@ -498,8 +665,9 @@ mod tests {
             path: "file0".to_string(),
             local_hash: hash_bytes(bytes),
             server_version: 0,
+            upload_id: None,
         };
-        db::put(&db, sync_record).unwrap();
+        db::put(&db, &sync_record).unwrap();
 
         push_single_file(&db, &mock_client, temp_dir.path(), &file)
             .await
@@ -530,8 +698,9 @@ mod tests {
             path: "file0".to_string(),
             local_hash: hash_bytes(bytes),
             server_version: 0,
+            upload_id: None,
         };
-        db::put(&db, sync_record).unwrap();
+        db::put(&db, &sync_record).unwrap();
 
         push(&db, &mock_client, temp_dir.path()).await.unwrap();
 
@@ -551,8 +720,9 @@ mod tests {
             path: "file0".to_string(),
             local_hash: hash_bytes(bytes),
             server_version: 0,
+            upload_id: None,
         };
-        db::put(&db, sync_record).unwrap();
+        db::put(&db, &sync_record).unwrap();
 
         push(&db, &mock_client, temp_dir.path()).await.unwrap();
 
@@ -582,8 +752,9 @@ mod tests {
             path: "file0".to_string(),
             local_hash: hash_bytes(bytes),
             server_version: 2,
+            upload_id: None,
         };
-        db::put(&db, sync_record).unwrap();
+        db::put(&db, &sync_record).unwrap();
 
         pull_single_file(&db, &mock_client, temp_dir.path(), &file_meta)
             .await
@@ -605,8 +776,9 @@ mod tests {
             path: "file0".to_string(),
             local_hash: hash_bytes(bytes),
             server_version: 1,
+            upload_id: None,
         };
-        db::put(&db, sync_record).unwrap();
+        db::put(&db, &sync_record).unwrap();
 
         pull_single_file(&db, &mock_client, temp_dir.path(), &file_meta)
             .await
@@ -630,8 +802,9 @@ mod tests {
             path: "subdir/file0".to_string(),
             local_hash: "somethingelse".to_string(),
             server_version: 1,
+            upload_id: None,
         };
-        db::put(&db, sync_record).unwrap();
+        db::put(&db, &sync_record).unwrap();
 
         pull_single_file(&db, &mock_client, temp_dir.path(), &file_meta)
             .await

--- a/crates/cloudsync-client/src/sync.rs
+++ b/crates/cloudsync-client/src/sync.rs
@@ -177,6 +177,7 @@ pub async fn push_single_file_chunked(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn resume_upload(
     upload_id: &str,
     db: &Database,
@@ -191,7 +192,7 @@ pub async fn resume_upload(
 ) -> anyhow::Result<()> {
     if let Some(sr) = &mut sync_record {
         sr.upload_id = Some(upload_id.to_string());
-        db::put(db, &sr)?;
+        db::put(db, sr)?;
     } else {
         let sr = SyncRecord {
             path: rel_path.clone(),
@@ -218,7 +219,7 @@ pub async fn resume_upload(
         if chunks_received.contains(&(idx as u32)) {
             continue;
         }
-        let fut = sync_client.send_chunk(&upload_id, idx as u32, buf);
+        let fut = sync_client.send_chunk(upload_id, idx as u32, buf);
         join_set.push(fut);
         if join_set.len() == batch_size {
             let results = futures::future::join_all(join_set.drain(..)).await;
@@ -236,7 +237,7 @@ pub async fn resume_upload(
         }
     }
 
-    let resp = sync_client.finalize_upload(&upload_id).await?;
+    let resp = sync_client.finalize_upload(upload_id).await?;
     let sync_record = SyncRecord {
         path: rel_path.clone(),
         local_hash: hash,

--- a/crates/cloudsync-client/src/sync.rs
+++ b/crates/cloudsync-client/src/sync.rs
@@ -44,6 +44,7 @@ pub async fn push(
     db: &Database,
     sync_client: &impl SyncApi,
     sync_root: &Path,
+    on_file_start: &impl Fn(&str, u64, u64) -> Box<dyn Fn()>,
 ) -> anyhow::Result<()> {
     let ignored = scanner::get_ignored(sync_root);
     let local_paths = scanner::scan_dir(sync_root, &ignored)?;
@@ -60,7 +61,7 @@ pub async fn push(
                 continue;
             }
         } else if let Err(e) =
-            push_single_file_chunked(db, sync_client, sync_root, local_path).await
+            push_single_file_chunked(db, sync_client, sync_root, local_path, on_file_start).await
         {
             println!(
                 "error pushing chunked {}: {}",
@@ -119,6 +120,7 @@ pub async fn push_single_file_chunked(
     sync_client: &impl SyncApi,
     sync_root: &Path,
     local_path: &Path,
+    on_file_start: &impl Fn(&str, u64, u64) -> Box<dyn Fn()>,
 ) -> anyhow::Result<()> {
     let total_size = local_path.metadata()?.len();
     let chunk_count = total_size.div_ceil(CHUNK_SIZE);
@@ -170,6 +172,7 @@ pub async fn push_single_file_chunked(
         chunk_count,
         rel_path,
         hash,
+        on_file_start,
     )
     .await
 }
@@ -184,6 +187,7 @@ pub async fn resume_upload(
     chunk_count: u64,
     rel_path: String,
     hash: String,
+    on_file_start: impl Fn(&str, u64, u64) -> Box<dyn Fn()>,
 ) -> anyhow::Result<()> {
     if let Some(sr) = &mut sync_record {
         sr.upload_id = Some(upload_id.to_string());
@@ -206,6 +210,7 @@ pub async fn resume_upload(
     let mut join_set = vec![];
 
     let chunks_received: std::collections::HashSet<u32> = chunks_received.into_iter().collect();
+    let on_progress = on_file_start(&rel_path, chunk_count, chunks_received.len() as u64);
     for idx in 0..chunk_count {
         let mut buf = Vec::new();
         (&mut file).take(CHUNK_SIZE).read_to_end(&mut buf)?;
@@ -219,6 +224,7 @@ pub async fn resume_upload(
             let results = futures::future::join_all(join_set.drain(..)).await;
             for res in results {
                 res?;
+                on_progress();
             }
         }
     }
@@ -568,6 +574,10 @@ mod tests {
         return (db, mock_client, temp_dir);
     }
 
+    fn noop_progress() -> impl Fn(&str, u64, u64) -> Box<dyn Fn()> {
+        |_: &str, _: u64, _: u64| -> Box<dyn Fn()> { Box::new(|| {}) }
+    }
+
     #[tokio::test]
     async fn test_push_single_file() {
         let (db, mock_client, temp_dir) = setup();
@@ -591,7 +601,7 @@ mod tests {
         let bytes = vec![0u8; 10 * 1024 * 1024];
         std::fs::write(&file, bytes).unwrap();
 
-        push_single_file_chunked(&db, &mock_client, temp_dir.path(), &file)
+        push_single_file_chunked(&db, &mock_client, temp_dir.path(), &file, &noop_progress())
             .await
             .unwrap();
 
@@ -619,7 +629,7 @@ mod tests {
         mock_client.set_upload_chunks_received(vec![1, 3, 4]);
         mock_client.set_upload_chunk_count(5);
 
-        push_single_file_chunked(&db, &mock_client, temp_dir.path(), &file)
+        push_single_file_chunked(&db, &mock_client, temp_dir.path(), &file, &noop_progress())
             .await
             .unwrap();
 
@@ -646,7 +656,7 @@ mod tests {
         db::put(&db, &sync_record).unwrap();
         mock_client.set_upload_fail_id("test_upload".to_string());
 
-        push_single_file_chunked(&db, &mock_client, temp_dir.path(), &file)
+        push_single_file_chunked(&db, &mock_client, temp_dir.path(), &file, &noop_progress())
             .await
             .unwrap();
 
@@ -666,7 +676,9 @@ mod tests {
         std::fs::write(&file, &bytes).unwrap();
         mock_client.set_send_chunk_fails(true);
 
-        let result = push_single_file_chunked(&db, &mock_client, temp_dir.path(), &file).await;
+        let result =
+            push_single_file_chunked(&db, &mock_client, temp_dir.path(), &file, &noop_progress())
+                .await;
 
         let record = db::get(&db, "file0").unwrap();
         assert!(result.is_err());
@@ -706,7 +718,9 @@ mod tests {
         std::fs::write(file0, b"hello world").unwrap();
         std::fs::write(file1, b"hello world").unwrap();
 
-        push(&db, &mock_client, temp_dir.path()).await.unwrap();
+        push(&db, &mock_client, temp_dir.path(), &noop_progress())
+            .await
+            .unwrap();
 
         assert_eq!(*mock_client.create_count.borrow(), 2);
         assert_eq!(*mock_client.delete_count.borrow(), 0);
@@ -724,7 +738,9 @@ mod tests {
         };
         db::put(&db, &sync_record).unwrap();
 
-        push(&db, &mock_client, temp_dir.path()).await.unwrap();
+        push(&db, &mock_client, temp_dir.path(), &noop_progress())
+            .await
+            .unwrap();
 
         assert_eq!(*mock_client.create_count.borrow(), 0);
         assert_eq!(*mock_client.delete_count.borrow(), 1);
@@ -746,7 +762,9 @@ mod tests {
         };
         db::put(&db, &sync_record).unwrap();
 
-        push(&db, &mock_client, temp_dir.path()).await.unwrap();
+        push(&db, &mock_client, temp_dir.path(), &noop_progress())
+            .await
+            .unwrap();
 
         assert_eq!(*mock_client.create_count.borrow(), 1);
         assert_eq!(*mock_client.delete_count.borrow(), 0);

--- a/crates/cloudsync-client/tests/integration_test.rs
+++ b/crates/cloudsync-client/tests/integration_test.rs
@@ -57,7 +57,7 @@ async fn test_push_and_pull() {
     std::fs::write(&file3, &bytes3).unwrap();
 
     // push
-    sync::push(&db, &sync_client, client_root_dir.path())
+    sync::push(&db, &sync_client, client_root_dir.path(), &noop_progress())
         .await
         .unwrap();
 
@@ -125,7 +125,7 @@ async fn test_pull_conflict() {
     std::fs::write(&file1, bytes1).unwrap();
 
     // push
-    sync::push(&db, &sync_client, client_root_dir.path())
+    sync::push(&db, &sync_client, client_root_dir.path(), &noop_progress())
         .await
         .unwrap();
 
@@ -144,9 +144,14 @@ async fn test_pull_conflict() {
         "hello world other client changed",
     )
     .unwrap();
-    sync::push(&other_db, &sync_client, other_client_root_dir.path())
-        .await
-        .unwrap();
+    sync::push(
+        &other_db,
+        &sync_client,
+        other_client_root_dir.path(),
+        &noop_progress(),
+    )
+    .await
+    .unwrap();
 
     // Pull with first client again
     sync::pull(&db, &sync_client, client_root_dir.path())
@@ -166,4 +171,8 @@ async fn test_pull_conflict() {
             .contains("file0.conflict")
     });
     assert!(conflict_exist);
+}
+
+fn noop_progress() -> impl Fn(&str, u64, u64) -> Box<dyn Fn()> {
+    |_: &str, _: u64, _: u64| -> Box<dyn Fn()> { Box::new(|| {}) }
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,12 +29,21 @@ See GitHub issues for details:
 - Skip completed chunks, upload only what's missing
 - Handle expired/cleaned-up uploads gracefully (restart from scratch)
 - Parallel chunk uploads (e.g. `tokio::JoinSet`) for faster large-file transfers
-- Graceful upload cancellation (Ctrl+C / cancellation token) — upload ID persisted so it can resume later
+- Parallel small-file uploads to reduce latency overhead when syncing many files below chunk threshold
 
 ### Resumable downloads
 - Server: support HTTP `Range` requests on `GET /api/v1/files/{path}`
 - Client: on interrupted download, resume from last byte received
 - Verify final file hash after reassembly
+
+---
+
+## Phase 1.5: Storage hygiene
+
+### Server-side garbage collection
+- Purge incomplete/expired uploads (orphaned chunks from abandoned uploads)
+- Permanently remove soft-deleted files (`is_deleted`) after a configurable retention period
+- Reclaim content-addressable blobs no longer referenced by any file metadata
 
 ---
 
@@ -62,6 +71,7 @@ See GitHub issues for details:
 - Watch a local folder, auto-sync changes (push on file change, periodic pull)
 - Reuse existing Rust client crate as the sync engine
 - Minimal UI: sync status, recent activity, settings (server URL, token, sync folder)
+- Graceful upload cancellation (cancellation token) — cancel button needs to stop uploads without killing the app
 
 ### Conflict resolution UX
 - Surface conflicts in the desktop app and web UI

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,6 +28,8 @@ See GitHub issues for details:
 - Client checks `GET /api/v1/uploads/{upload_id}` on start to find already-received chunks
 - Skip completed chunks, upload only what's missing
 - Handle expired/cleaned-up uploads gracefully (restart from scratch)
+- Parallel chunk uploads (e.g. `tokio::JoinSet`) for faster large-file transfers
+- Graceful upload cancellation (Ctrl+C / cancellation token) — upload ID persisted so it can resume later
 
 ### Resumable downloads
 - Server: support HTTP `Range` requests on `GET /api/v1/files/{path}`

--- a/scripts/BENCH_RESULTS.md
+++ b/scripts/BENCH_RESULTS.md
@@ -1,0 +1,39 @@
+# Upload Benchmark Results (2026-04-20)
+
+Tested parallel chunk uploads against cloudsync.devchris.dev (Hetzner CX22 VPS).
+
+## Setup
+
+- Home connection: ~40 Mbps upload / 100 Mbps download
+- CHUNK_SIZE: 4MB
+- Server: Hetzner CX22, Ubuntu 24.04
+
+## Results
+
+### 100MB file (25 chunks)
+
+| Batch size | Time  |
+|------------|-------|
+| 1          | 24s   |
+| 5          | 21s   |
+
+### 500MB file (125 chunks)
+
+| Batch size | Time    |
+|------------|---------|
+| 1          | 1m 48s  |
+| 5          | ~1m 44s |
+| 20         | 1m 44s  |
+
+## Analysis
+
+Measured upload throughput: ~4.6 MB/s (~37 Mbps), which is ~92% of the 40 Mbps connection cap.
+
+**Bandwidth is the bottleneck, not latency.** Parallel sends only eliminate idle time between server round-trips (the gap waiting for "chunk received" before sending the next). Once the pipe is saturated (~batch=5), adding more parallel streams doesn't help — chunks queue at the OS TCP buffer level and take turns on the wire.
+
+## Why we still use batch=5
+
+- Captures the small latency-gap savings (~3-4s on large files)
+- Helps more on high-latency connections (e.g. overseas servers)
+- No downside when bandwidth-limited — same total throughput
+- The real value of chunked uploads is **resumability**, not speed

--- a/scripts/bench-upload.sh
+++ b/scripts/bench-upload.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/bench-upload.sh [size_mb] [batch_size]
+# Requires: cloudsync init already run in a sync directory
+
+SIZE_MB="${1:-100}"
+BATCH_SIZE="${2:-5}"
+SYNC_DIR="${CLOUDSYNC_BENCH_DIR:-/tmp/cloudsync-bench}"
+TEST_FILE="$SYNC_DIR/bench-${SIZE_MB}mb.bin"
+
+echo "=== CloudSync upload benchmark ==="
+echo "File size:   ${SIZE_MB}MB"
+echo "Batch size:  ${BATCH_SIZE}"
+echo "Sync dir:    $SYNC_DIR"
+echo ""
+
+# Setup sync dir if needed
+mkdir -p "$SYNC_DIR/.cloudsync"
+if [ ! -f "$SYNC_DIR/.cloudsync/config.toml" ]; then
+    echo "Error: run 'cloudsync init' in $SYNC_DIR first"
+    exit 1
+fi
+
+# Generate test file
+echo "Generating ${SIZE_MB}MB test file..."
+dd if=/dev/urandom of="$TEST_FILE" bs=1M count="$SIZE_MB" 2>/dev/null
+echo ""
+
+# Run push and time it
+echo "Pushing..."
+cd "$SYNC_DIR"
+time CLOUDSYNC_BATCH_SIZE="$BATCH_SIZE" cargo run --release -p cloudsync-client -- push
+
+# Cleanup
+echo ""
+echo "Cleaning up test file..."
+rm -f "$TEST_FILE"
+echo "Done. Delete the file from the server manually if needed."


### PR DESCRIPTION
Closes #18

## Summary
- Implement upload resumption: persist `upload_id` to `SyncRecord`, check server for already-received chunks, skip them, send only what's missing
- Handle expired uploads gracefully by falling back to a fresh `init_upload`
- Send chunks in parallel batches (default 5, tunable via `CLOUDSYNC_BATCH_SIZE`) to fill idle gaps between server round-trips
- Add progress bar for chunked uploads using indicatif, with correct starting position on resume
- Change `db::put` to take `&SyncRecord` instead of owned value
- Add bench script for measuring upload throughput
- Update roadmap: storage hygiene phase, parallel small-file uploads, move cancellation to Phase 3

## Test plan
- [x] Fresh chunked upload sends all chunks and finalizes
- [x] Resume skips already-received chunks (sends only missing ones)
- [x] Expired upload falls back to fresh init_upload
- [x] Crash mid-upload persists upload_id for later resumption
- [x] Existing push/pull/skip/delete tests still pass