### PR TITLE
Implement resumable downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -755,6 +756,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -1978,11 +1985,20 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,14 @@ tokio-util = { version = "0.7", features = ["io"] }
 redb = { version = "2.0" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "stream", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+    "json",
+    "multipart",
+    "stream",
+    "rustls-tls",
+] }
 clap = { version = "4.0", features = ["derive", "env"] }
 toml = { version = "0.8" }
 anyhow = { version = "1.0" }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "fs"] }
+tower = "0.5"

--- a/crates/cloudsync-client/src/client.rs
+++ b/crates/cloudsync-client/src/client.rs
@@ -2,9 +2,9 @@ use cloudsync_common::{
     CreateFileResponse, DeleteFileResponse, FinalizeUploadResponse, GetUploadResponse,
     InitUploadRequest, InitUploadResponse, ListFilesResponse,
 };
-use tokio::io::AsyncRead;
+use reqwest::StatusCode;
 
-use crate::sync::SyncApi;
+use crate::sync::{DownloadFileResponse, SyncApi};
 use futures::TryStreamExt;
 
 pub struct SyncClient {
@@ -78,10 +78,16 @@ impl SyncApi for SyncClient {
         Ok(serde_json::from_slice::<CreateFileResponse>(&bytes)?)
     }
 
-    async fn get_file(&self, path: &str) -> anyhow::Result<Box<dyn AsyncRead + Unpin + Send>> {
+    async fn get_file(&self, path: &str, start_bytes: u64) -> anyhow::Result<DownloadFileResponse> {
         let url = format!("{}/{}/{}", self.server_url, "api/v1/files", path);
         tracing::debug!("request: {} {}", "get", &url);
-        let resp = self.client.get(url).bearer_auth(&self.token).send().await?;
+
+        let mut req = self.client.get(url).bearer_auth(&self.token);
+        if start_bytes > 0 {
+            req = req.header(reqwest::header::RANGE, format!("bytes={start_bytes}-"));
+        }
+        let resp = req.send().await?;
+
         let status = resp.status();
         if !status.is_success() {
             anyhow::bail!(
@@ -93,7 +99,11 @@ impl SyncApi for SyncClient {
         let bytes_stream = resp.bytes_stream();
         let stream = bytes_stream.map_err(std::io::Error::other);
         let reader = tokio_util::io::StreamReader::new(stream);
-        Ok(Box::new(reader))
+
+        Ok(DownloadFileResponse {
+            resumed: status == StatusCode::PARTIAL_CONTENT,
+            stream: Box::new(reader),
+        })
     }
 
     async fn delete_file(&self, path: &str) -> anyhow::Result<DeleteFileResponse> {

--- a/crates/cloudsync-client/src/main.rs
+++ b/crates/cloudsync-client/src/main.rs
@@ -25,19 +25,13 @@ async fn main() -> anyhow::Result<()> {
         }
         cli::Command::Push => {
             let (db, sync_client, sync_root) = setup().await?;
-            let mp = MultiProgress::new();
-            let on_file_start = |path: &str, count: u64, completed: u64| -> Box<dyn Fn()> {
-                let pb = mp.add(ProgressBar::new(count));
-                pb.set_position(completed);
-                pb.set_style(ProgressStyle::with_template("{msg} [{bar:20}] {pos}/{len}").unwrap());
-                pb.set_message(path.to_string());
-                Box::new(move || pb.inc(1))
-            };
+            let on_file_start = create_on_file_start_fixed_inc();
             sync::push(&db, &sync_client, &sync_root, &on_file_start).await?;
         }
         cli::Command::Pull => {
             let (db, sync_client, sync_root) = setup().await?;
-            sync::pull(&db, &sync_client, &sync_root).await?;
+            let on_file_start = create_on_file_start_var_inc();
+            sync::pull(&db, &sync_client, &sync_root, &on_file_start).await?;
         }
         cli::Command::Status => {
             let (db, sync_client, sync_root) = setup().await?;
@@ -65,4 +59,26 @@ fn load_config() -> anyhow::Result<ClientConfig> {
         anyhow::bail!("Not initialized. Run 'cloudsync init' first.")
     }
     config::ClientConfig::load()
+}
+
+fn create_on_file_start_fixed_inc() -> impl Fn(&str, u64, u64) -> Box<dyn Fn()> {
+    let mp = MultiProgress::new();
+    move |path: &str, count: u64, completed: u64| -> Box<dyn Fn()> {
+        let pb = mp.add(ProgressBar::new(count));
+        pb.set_position(completed);
+        pb.set_style(ProgressStyle::with_template("{msg} [{bar:20}] {pos}/{len}").unwrap());
+        pb.set_message(path.to_string());
+        Box::new(move || pb.inc(1))
+    }
+}
+
+fn create_on_file_start_var_inc() -> impl Fn(&str, u64, u64) -> Box<dyn Fn(u64)> {
+    let mp = MultiProgress::new();
+    move |path: &str, count: u64, completed: u64| -> Box<dyn Fn(u64)> {
+        let pb = mp.add(ProgressBar::new(count));
+        pb.set_position(completed);
+        pb.set_style(ProgressStyle::with_template("{msg} [{bar:20}] {pos}/{len}").unwrap());
+        pb.set_message(path.to_string());
+        Box::new(move |inc: u64| pb.inc(inc))
+    }
 }

--- a/crates/cloudsync-client/src/sync.rs
+++ b/crates/cloudsync-client/src/sync.rs
@@ -1,5 +1,6 @@
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 
 use cloudsync_common::{
     CreateFileResponse, DeleteFileResponse, FileMeta, FinalizeUploadResponse, GetUploadResponse,
@@ -17,6 +18,27 @@ pub const CHUNK_SIZE: u64 = 4 * 1024 * 1024;
 pub struct DownloadFileResponse {
     pub resumed: bool,
     pub stream: Box<dyn AsyncRead + Unpin + Send>,
+}
+
+struct ProgressReader<R> {
+    inner: R,
+    on_bytes: Box<dyn Fn(u64)>,
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for ProgressReader<R> {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let before = buf.filled().len();
+        let result = Pin::new(&mut self.inner).poll_read(cx, buf);
+        if let std::task::Poll::Ready(Ok(())) = &result {
+            let bytes_read = buf.filled().len() - before;
+            (self.on_bytes)(bytes_read as u64);
+        }
+        result
+    }
 }
 
 #[allow(async_fn_in_trait)]
@@ -269,10 +291,13 @@ pub async fn pull(
     db: &Database,
     sync_client: &impl SyncApi,
     sync_root: &Path,
+    on_file_start: &impl Fn(&str, u64, u64) -> Box<dyn Fn(u64)>,
 ) -> anyhow::Result<()> {
     let file_metas = sync_client.list_files().await?.files;
     for file_meta in file_metas {
-        if let Err(e) = pull_single_file(db, sync_client, sync_root, &file_meta).await {
+        if let Err(e) =
+            pull_single_file(db, sync_client, sync_root, &file_meta, on_file_start).await
+        {
             println!("error pulling {}: {}", &file_meta.path, e);
             continue;
         }
@@ -285,6 +310,7 @@ async fn pull_single_file(
     sync_client: &impl SyncApi,
     sync_root: &Path,
     file_meta: &FileMeta,
+    on_file_start: &impl Fn(&str, u64, u64) -> Box<dyn Fn(u64)>,
 ) -> anyhow::Result<()> {
     let record = db::get(db, &file_meta.path)?;
 
@@ -314,8 +340,18 @@ async fn pull_single_file(
                     conflict_path_backup.push(".part");
                     let conflict_path_backup = PathBuf::from(conflict_path_backup);
 
-                    download_to_file(sync_client, &file_meta.path, &conflict_path_backup).await?;
-
+                    let bytes_on_file = tokio::fs::metadata(&conflict_path_backup)
+                        .await
+                        .map(|m| m.len())
+                        .unwrap_or(0);
+                    let on_bytes = on_file_start(&file_meta.path, file_meta.size, bytes_on_file);
+                    download_to_file(
+                        sync_client,
+                        &file_meta.path,
+                        &conflict_path_backup,
+                        on_bytes,
+                    )
+                    .await?;
                     let conflict_backup_hash = hash_file(&conflict_path_backup)?;
                     if file_meta.content_hash != conflict_backup_hash {
                         std::fs::remove_file(conflict_path_backup)?;
@@ -339,7 +375,13 @@ async fn pull_single_file(
     let mut local_path_backup = local_path.as_os_str().to_owned();
     local_path_backup.push(".part");
     let local_path_backup = PathBuf::from(local_path_backup);
-    download_to_file(sync_client, &file_meta.path, &local_path_backup).await?;
+
+    let bytes_on_file = tokio::fs::metadata(&local_path_backup)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let on_bytes = on_file_start(&file_meta.path, file_meta.size, bytes_on_file);
+    download_to_file(sync_client, &file_meta.path, &local_path_backup, on_bytes).await?;
     let local_backup_hash = hash_file(&local_path_backup)?;
     if file_meta.content_hash != local_backup_hash {
         std::fs::remove_file(local_path_backup)?;
@@ -365,12 +407,13 @@ pub async fn download_to_file(
     sync_client: &impl SyncApi,
     src_path: &str,
     dest: &Path,
+    on_bytes: Box<dyn Fn(u64)>,
 ) -> anyhow::Result<()> {
     let bytes_on_file = tokio::fs::metadata(&dest)
         .await
         .map(|m| m.len())
         .unwrap_or(0);
-    let mut resp = sync_client.get_file(src_path, bytes_on_file).await?;
+    let resp = sync_client.get_file(src_path, bytes_on_file).await?;
     let mut file_opts = tokio::fs::OpenOptions::new();
     file_opts.create(true);
     let mut file = if resp.resumed {
@@ -378,7 +421,11 @@ pub async fn download_to_file(
     } else {
         file_opts.truncate(true).write(true).open(&dest).await?
     };
-    tokio::io::copy(&mut resp.stream, &mut file).await?;
+    let mut progress_streamer = ProgressReader {
+        inner: resp.stream,
+        on_bytes,
+    };
+    tokio::io::copy(&mut progress_streamer, &mut file).await?;
     Ok(())
 }
 
@@ -631,6 +678,10 @@ mod tests {
         |_: &str, _: u64, _: u64| -> Box<dyn Fn()> { Box::new(|| {}) }
     }
 
+    fn noop_download_progress() -> impl Fn(&str, u64, u64) -> Box<dyn Fn(u64)> {
+        |_: &str, _: u64, _: u64| -> Box<dyn Fn(u64)> { Box::new(|_| {}) }
+    }
+
     #[tokio::test]
     async fn test_push_single_file() {
         let (db, mock_client, temp_dir) = setup();
@@ -829,9 +880,15 @@ mod tests {
 
         let file_meta = make_file_meta("file0", 0);
 
-        pull_single_file(&db, &mock_client, temp_dir.path(), &file_meta)
-            .await
-            .unwrap();
+        pull_single_file(
+            &db,
+            &mock_client,
+            temp_dir.path(),
+            &file_meta,
+            &noop_download_progress(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(*mock_client.get_count.borrow(), 1);
     }
@@ -849,9 +906,15 @@ mod tests {
         };
         db::put(&db, &sync_record).unwrap();
 
-        pull_single_file(&db, &mock_client, temp_dir.path(), &file_meta)
-            .await
-            .unwrap();
+        pull_single_file(
+            &db,
+            &mock_client,
+            temp_dir.path(),
+            &file_meta,
+            &noop_download_progress(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(*mock_client.get_count.borrow(), 0);
     }
@@ -873,9 +936,15 @@ mod tests {
         };
         db::put(&db, &sync_record).unwrap();
 
-        pull_single_file(&db, &mock_client, temp_dir.path(), &file_meta)
-            .await
-            .unwrap();
+        pull_single_file(
+            &db,
+            &mock_client,
+            temp_dir.path(),
+            &file_meta,
+            &noop_download_progress(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(*mock_client.get_count.borrow(), 1);
     }
@@ -899,9 +968,15 @@ mod tests {
         };
         db::put(&db, &sync_record).unwrap();
 
-        pull_single_file(&db, &mock_client, temp_dir.path(), &file_meta)
-            .await
-            .unwrap();
+        pull_single_file(
+            &db,
+            &mock_client,
+            temp_dir.path(),
+            &file_meta,
+            &noop_download_progress(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(*mock_client.get_count.borrow(), 1);
         let conflict_exists = std::fs::read_dir(subdir).unwrap().into_iter().any(|f| {
@@ -937,7 +1012,14 @@ mod tests {
         let file_meta1 = make_file_meta("file01", 2);
         mock_client.set_files(vec![file_meta0, file_meta1]);
 
-        pull(&db, &mock_client, temp_dir.path()).await.unwrap();
+        pull(
+            &db,
+            &mock_client,
+            temp_dir.path(),
+            &noop_download_progress(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(*mock_client.list_count.borrow(), 1);
         assert_eq!(*mock_client.get_count.borrow(), 2)
@@ -955,7 +1037,14 @@ mod tests {
         mock_client.set_files(vec![file_meta0, file_meta1]);
         mock_client.set_fail_path("file1".to_string());
 
-        pull(&db, &mock_client, temp_dir.path()).await.unwrap();
+        pull(
+            &db,
+            &mock_client,
+            temp_dir.path(),
+            &noop_download_progress(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(*mock_client.list_count.borrow(), 1);
         assert_eq!(*mock_client.get_count.borrow(), 1)

--- a/crates/cloudsync-client/src/sync.rs
+++ b/crates/cloudsync-client/src/sync.rs
@@ -1,5 +1,5 @@
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use cloudsync_common::{
     CreateFileResponse, DeleteFileResponse, FileMeta, FinalizeUploadResponse, GetUploadResponse,
@@ -14,12 +14,17 @@ use crate::scanner::{self, scan_dir};
 
 pub const CHUNK_SIZE: u64 = 4 * 1024 * 1024;
 
+pub struct DownloadFileResponse {
+    pub resumed: bool,
+    pub stream: Box<dyn AsyncRead + Unpin + Send>,
+}
+
 #[allow(async_fn_in_trait)]
 pub trait SyncApi {
     async fn list_files(&self) -> anyhow::Result<ListFilesResponse>;
     async fn create_file(&self, path: &str, content: Vec<u8>)
     -> anyhow::Result<CreateFileResponse>;
-    async fn get_file(&self, path: &str) -> anyhow::Result<Box<dyn AsyncRead + Unpin + Send>>;
+    async fn get_file(&self, path: &str, start_bytes: u64) -> anyhow::Result<DownloadFileResponse>;
     async fn delete_file(&self, path: &str) -> anyhow::Result<DeleteFileResponse>;
     async fn init_upload(&self, request: InitUploadRequest) -> anyhow::Result<InitUploadResponse>;
     async fn send_chunk(
@@ -304,9 +309,22 @@ async fn pull_single_file(
                     let conflict_path = sync_root
                         .join(&file_meta.path)
                         .with_file_name(conflict_path);
-                    let mut file = tokio::fs::File::create(&conflict_path).await?;
-                    let mut stream_reader = sync_client.get_file(&file_meta.path).await?;
-                    tokio::io::copy(&mut stream_reader, &mut file).await?;
+
+                    let mut conflict_path_backup = conflict_path.as_os_str().to_owned();
+                    conflict_path_backup.push(".part");
+                    let conflict_path_backup = PathBuf::from(conflict_path_backup);
+
+                    download_to_file(sync_client, &file_meta.path, &conflict_path_backup).await?;
+
+                    let conflict_backup_hash = hash_file(&conflict_path_backup)?;
+                    if file_meta.content_hash != conflict_backup_hash {
+                        std::fs::remove_file(conflict_path_backup)?;
+                        anyhow::bail!(
+                            "Corrupt download: hash does not match for {}",
+                            &file_meta.path
+                        );
+                    }
+                    std::fs::rename(conflict_path_backup, &conflict_path)?;
                     println!("Conflict: resolve conflict in {}", conflict_path.display());
                     return Ok(());
                 }
@@ -318,18 +336,49 @@ async fn pull_single_file(
     if let Some(parent_dir) = parent_dir {
         std::fs::create_dir_all(parent_dir)?;
     };
-    let mut stream_reader = sync_client.get_file(&file_meta.path).await?;
-    let mut file = tokio::fs::File::create(local_path).await?;
-    tokio::io::copy(&mut stream_reader, &mut file).await?;
+    let mut local_path_backup = local_path.as_os_str().to_owned();
+    local_path_backup.push(".part");
+    let local_path_backup = PathBuf::from(local_path_backup);
+    download_to_file(sync_client, &file_meta.path, &local_path_backup).await?;
+    let local_backup_hash = hash_file(&local_path_backup)?;
+    if file_meta.content_hash != local_backup_hash {
+        std::fs::remove_file(local_path_backup)?;
+        anyhow::bail!(
+            "Corrupt download: hash does not match for {}",
+            &file_meta.path
+        );
+    }
+    std::fs::rename(local_path_backup, local_path)?;
     let sync_record = SyncRecord {
         path: file_meta.path.clone(),
-        local_hash: hash_file(local_path)?,
+        local_hash: local_backup_hash,
         server_version: file_meta.version,
         upload_id: None,
     };
     db::put(db, &sync_record)?;
     println!("pulled: {}", &file_meta.path);
 
+    Ok(())
+}
+
+pub async fn download_to_file(
+    sync_client: &impl SyncApi,
+    src_path: &str,
+    dest: &Path,
+) -> anyhow::Result<()> {
+    let bytes_on_file = tokio::fs::metadata(&dest)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let mut resp = sync_client.get_file(src_path, bytes_on_file).await?;
+    let mut file_opts = tokio::fs::OpenOptions::new();
+    file_opts.create(true);
+    let mut file = if resp.resumed {
+        file_opts.append(true).open(&dest).await?
+    } else {
+        file_opts.truncate(true).write(true).open(&dest).await?
+    };
+    tokio::io::copy(&mut resp.stream, &mut file).await?;
     Ok(())
 }
 
@@ -493,12 +542,15 @@ mod tests {
             })
         }
 
-        async fn get_file(&self, path: &str) -> anyhow::Result<Box<dyn AsyncRead + Unpin + Send>> {
+        async fn get_file(&self, path: &str, _bytes: u64) -> anyhow::Result<DownloadFileResponse> {
             if self.fail_path.borrow().as_deref() == Some(path) {
                 anyhow::bail!("error");
             }
             *self.get_count.borrow_mut() += 1;
-            Ok(Box::new(std::io::Cursor::new(Vec::new())))
+            Ok(DownloadFileResponse {
+                resumed: false,
+                stream: Box::new(std::io::Cursor::new(Vec::new())),
+            })
         }
 
         async fn delete_file(&self, _path: &str) -> anyhow::Result<DeleteFileResponse> {
@@ -866,7 +918,7 @@ mod tests {
         FileMeta {
             path: path.to_string(),
             size: 0,
-            content_hash: "".to_string(),
+            content_hash: hash_bytes(&[]),
             version,
             is_deleted: false,
             created_at: chrono::Utc::now(),

--- a/crates/cloudsync-client/tests/integration_test.rs
+++ b/crates/cloudsync-client/tests/integration_test.rs
@@ -8,6 +8,10 @@ use cloudsync_client::{
 use cloudsync_server::config::ServerConfig;
 use tokio::{self, net::TcpListener};
 
+fn noop_download_progress() -> impl Fn(&str, u64, u64) -> Box<dyn Fn(u64)> {
+    |_: &str, _: u64, _: u64| -> Box<dyn Fn(u64)> { Box::new(|_| {}) }
+}
+
 #[tokio::test]
 async fn test_push_and_pull() {
     // start server
@@ -65,9 +69,14 @@ async fn test_push_and_pull() {
     let other_client_root_dir = tempfile::TempDir::new().unwrap();
     std::fs::create_dir_all(other_client_root_dir.path().join(".cloudsync")).unwrap();
     let other_db = open_db(other_client_root_dir.path()).unwrap();
-    sync::pull(&other_db, &sync_client, other_client_root_dir.path())
-        .await
-        .unwrap();
+    sync::pull(
+        &other_db,
+        &sync_client,
+        other_client_root_dir.path(),
+        &noop_download_progress(),
+    )
+    .await
+    .unwrap();
 
     // assert
     let pulled_bytes0 = std::fs::read(other_client_root_dir.path().join("file0")).unwrap();
@@ -136,9 +145,14 @@ async fn test_pull_conflict() {
     let other_client_root_dir = tempfile::TempDir::new().unwrap();
     std::fs::create_dir_all(other_client_root_dir.path().join(".cloudsync")).unwrap();
     let other_db = open_db(other_client_root_dir.path()).unwrap();
-    sync::pull(&other_db, &sync_client, other_client_root_dir.path())
-        .await
-        .unwrap();
+    sync::pull(
+        &other_db,
+        &sync_client,
+        other_client_root_dir.path(),
+        &noop_download_progress(),
+    )
+    .await
+    .unwrap();
     std::fs::write(
         other_client_root_dir.path().join("file0"),
         "hello world other client changed",
@@ -154,9 +168,14 @@ async fn test_pull_conflict() {
     .unwrap();
 
     // Pull with first client again
-    sync::pull(&db, &sync_client, client_root_dir.path())
-        .await
-        .unwrap();
+    sync::pull(
+        &db,
+        &sync_client,
+        client_root_dir.path(),
+        &noop_download_progress(),
+    )
+    .await
+    .unwrap();
 
     // assert
     let bytes0 = std::fs::read(client_root_dir.path().join("file0")).unwrap();

--- a/crates/cloudsync-server/Cargo.toml
+++ b/crates/cloudsync-server/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { workspace = true }
 clap = { workspace = true }
 tracing-subscriber = { workspace = true }
 tower-http = { workspace = true }
+tower = { workspace = true }
 tracing = { workspace = true }
 nanoid = "0.4"
 # Web UI

--- a/crates/cloudsync-server/src/app.rs
+++ b/crates/cloudsync-server/src/app.rs
@@ -10,6 +10,8 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{delete, get, post, put},
 };
+use tower::ServiceExt;
+use tower_http::services::ServeFile;
 use tower_http::trace::TraceLayer;
 
 use cloudsync_common::{
@@ -97,6 +99,7 @@ async fn delete_file(
 async fn get_file(
     State(state): State<AppState>,
     Path(path): Path<String>,
+    request: Request,
 ) -> Result<impl IntoResponse, AppError> {
     let db: Arc<Database> = state.db;
     let file_meta = db::get(&db, &path)?;
@@ -113,13 +116,9 @@ async fn get_file(
         file_meta.version
     );
     let content_hash = file_meta.content_hash;
-    let file = storage::read_async(&state.storage_dir, &content_hash).await?;
-    let reader_stream = tokio_util::io::ReaderStream::new(file);
-    let headers = [(
-        axum::http::header::CONTENT_LENGTH,
-        file_meta.size.to_string(),
-    )];
-    Ok((headers, axum::body::Body::from_stream(reader_stream)))
+    let path = storage::get_storage_path(&state.storage_dir, &content_hash);
+    let resp = ServeFile::new(path).oneshot(request).await?;
+    Ok(resp.into_response())
 }
 
 async fn create_upload(

--- a/crates/cloudsync-server/src/storage.rs
+++ b/crates/cloudsync-server/src/storage.rs
@@ -9,13 +9,6 @@ pub fn write(data_dir: &str, content: &[u8]) -> anyhow::Result<String> {
     Ok(content_hash)
 }
 
-pub async fn read_async(data_dir: &str, content_hash: &str) -> anyhow::Result<tokio::fs::File> {
-    let dir = std::path::Path::new(data_dir).join(&content_hash[0..2]);
-    let path = dir.join(content_hash);
-    let file = tokio::fs::File::open(path).await?;
-    Ok(file)
-}
-
 pub fn get_storage_path(data_dir: &str, total_hash: &str) -> std::path::PathBuf {
     std::path::Path::new(data_dir)
         .join(&total_hash[0..2])
@@ -42,5 +35,11 @@ mod test {
         let mut buf = Vec::new();
         file.take(1000).read_to_end(&mut buf).await.unwrap();
         assert_eq!(buf.as_slice(), bytes);
+    }
+
+    async fn read_async(data_dir: &str, content_hash: &str) -> anyhow::Result<tokio::fs::File> {
+        let path = get_storage_path(data_dir, content_hash);
+        let file = tokio::fs::File::open(path).await?;
+        Ok(file)
     }
 }

--- a/crates/cloudsync-server/tests/integration_test.rs
+++ b/crates/cloudsync-server/tests/integration_test.rs
@@ -6,6 +6,58 @@ use reqwest::StatusCode;
 use tokio::{self, net::TcpListener};
 
 #[tokio::test]
+async fn test_range_download() {
+    // start server
+    let token = "HELLO";
+    let storage_dir = tempfile::TempDir::new().unwrap();
+    let staging_dir = storage_dir.path().join("staging");
+    let storage_dir_str = storage_dir.path().to_str().unwrap().to_string();
+    let dbname = storage_dir
+        .path()
+        .join("server.redb")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let server = cloudsync_server::app::bootstrap_app(ServerConfig {
+        storage_dir: storage_dir_str,
+        staging_dir: staging_dir.to_str().unwrap().to_string(),
+        token: token.to_string(),
+        dbname: dbname.to_string(),
+    })
+    .unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, server).await.unwrap() });
+
+    // Initial upload
+    let base_url = format!("http://{addr}");
+    let client = reqwest::Client::new();
+    let file_bytes = b"abc";
+    let form = reqwest::multipart::Form::new()
+        .text("path", "my/file")
+        .part("file", reqwest::multipart::Part::bytes(file_bytes));
+    let response = client
+        .post(format!("{base_url}/api/v1/files"))
+        .bearer_auth(token)
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+    let status = response.status();
+    assert_eq!(status, StatusCode::OK);
+    let response = client
+        .get(format!("{base_url}/api/v1/files/my/file"))
+        .bearer_auth(token)
+        .header("Range", "bytes=2-")
+        .send()
+        .await
+        .unwrap();
+    let status = response.status();
+    assert_eq!(status, StatusCode::PARTIAL_CONTENT);
+    assert_eq!(response.bytes().await.unwrap().as_ref(), b"c");
+}
+
+#[tokio::test]
 async fn test_chunked_upload() {
     // start server
     let token = "HELLO";


### PR DESCRIPTION
Closes #19

## Summary
- Server: replace manual streaming with `tower-http::ServeFile` for automatic HTTP Range support
- Client: detect partial `.part` files on disk, send `Range` header to resume from last byte
- Downloads go to `.part` file first, then hash-verified against `content_hash` before renaming to final path
- Corrupted downloads are deleted so the next pull retries from scratch
- Add download progress bar using a `ProgressReader` wrapper that counts bytes as they stream through
- Handle servers that ignore Range (return 200 instead of 206) by truncating and starting over

## Test plan
- [x] Server returns 206 Partial Content for Range requests (integration test)
- [x] Fresh download writes to `.part` file, verifies hash, renames
- [x] Conflict downloads also use `.part` + hash verification pattern
- [x] All existing push/pull/skip/delete/conflict tests pass
- [x] Manual test: download progress bar renders correctly for large files