### PR TITLE
Scope all data to tenants with composite DB keys

### DIFF
--- a/crates/cloudsync-client/src/sync/mock_client.rs
+++ b/crates/cloudsync-client/src/sync/mock_client.rs
@@ -94,6 +94,8 @@ impl SyncApi for MockClient {
                 is_deleted: false,
                 created_at: chrono::Utc::now(),
                 modified_at: chrono::Utc::now(),
+                tenant_id: "tenant".to_string(),
+                user_id: "user".to_string(),
             },
         })
     }
@@ -149,6 +151,8 @@ impl SyncApi for MockClient {
                 chunks_received: (*self.get_upload_chunks_received.borrow()).clone(),
                 created_at: Utc::now(),
                 modified_at: Utc::now(),
+                tenant_id: "tenant".to_string(),
+                user_id: "user".to_string(),
             },
         })
     }
@@ -164,6 +168,8 @@ impl SyncApi for MockClient {
                 is_deleted: false,
                 created_at: Utc::now(),
                 modified_at: Utc::now(),
+                tenant_id: "tenant".to_string(),
+                user_id: "user".to_string(),
             },
         })
     }

--- a/crates/cloudsync-client/src/sync/pull.rs
+++ b/crates/cloudsync-client/src/sync/pull.rs
@@ -283,6 +283,8 @@ mod tests {
             is_deleted: false,
             created_at: chrono::Utc::now(),
             modified_at: chrono::Utc::now(),
+            tenant_id: "tenant".to_string(),
+            user_id: "user".to_string(),
         }
     }
 

--- a/crates/cloudsync-client/tests/integration_test.rs
+++ b/crates/cloudsync-client/tests/integration_test.rs
@@ -35,6 +35,8 @@ async fn test_push_and_pull() {
         staging_dir: staging_dir_str,
         token: token.to_string(),
         dbname: dbname.to_string(),
+        default_tenant_id: "tenant".to_string(),
+        default_user_id: "user".to_string(),
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -113,6 +115,8 @@ async fn test_pull_conflict() {
         staging_dir: staging_dir_str,
         token: token.to_string(),
         dbname: dbname.to_string(),
+        default_tenant_id: "tenant".to_string(),
+        default_user_id: "user".to_string(),
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/cloudsync-common/src/lib.rs
+++ b/crates/cloudsync-common/src/lib.rs
@@ -16,6 +16,10 @@ pub struct FileMeta {
     pub is_deleted: bool,
     pub created_at: DateTime<Utc>,
     pub modified_at: DateTime<Utc>,
+    #[serde(default)]
+    pub tenant_id: String,
+    #[serde(default)]
+    pub user_id: String,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/cloudsync-common/src/upload.rs
+++ b/crates/cloudsync-common/src/upload.rs
@@ -13,6 +13,10 @@ pub struct Upload {
     pub chunks_received: Vec<u32>,
     pub created_at: DateTime<Utc>,
     pub modified_at: DateTime<Utc>,
+    #[serde(default)]
+    pub tenant_id: String,
+    #[serde(default)]
+    pub user_id: String,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/cloudsync-server/src/app.rs
+++ b/crates/cloudsync-server/src/app.rs
@@ -4,7 +4,7 @@ use axum::{
     Json, Router,
     body::{self},
     debug_handler,
-    extract::{self, DefaultBodyLimit, Multipart, Path, Request, State},
+    extract::{self, DefaultBodyLimit, FromRequestParts, Multipart, Path, Request, State},
     http::StatusCode,
     middleware::Next,
     response::{IntoResponse, Response},
@@ -21,7 +21,9 @@ use cloudsync_common::{
 };
 use redb::Database;
 
-use crate::{config::ServerConfig, db_upload};
+use crate::{
+    auth::UserContext, config::ServerConfig, db::TenantDb, db_upload::TenantUploadDb, migrations,
+};
 
 use super::db;
 use super::storage;
@@ -32,6 +34,8 @@ pub struct AppState {
     pub storage_dir: String,
     pub staging_dir: String,
     pub token: String,
+    pub default_tenant_id: String,
+    pub default_user_id: String,
 }
 
 struct AppError(anyhow::Error, StatusCode);
@@ -51,16 +55,35 @@ impl<E: Into<anyhow::Error>> From<E> for AppError {
     }
 }
 
+impl<S: Send + Sync> FromRequestParts<S> for UserContext {
+    type Rejection = StatusCode;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _: &S,
+    ) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<UserContext>()
+            .cloned()
+            .ok_or(StatusCode::INTERNAL_SERVER_ERROR)
+    }
+}
+
 #[debug_handler]
-async fn list_files(State(state): State<AppState>) -> Result<Json<ListFilesResponse>, AppError> {
-    let db = state.db;
-    let files = db::list(&db)?;
+async fn list_files(
+    State(state): State<AppState>,
+    ctx: UserContext,
+) -> Result<Json<ListFilesResponse>, AppError> {
+    let db = TenantDb::new(state.db, ctx);
+    let files = db.list()?;
     Ok(Json(ListFilesResponse { files }))
 }
 
 #[debug_handler]
 async fn post_file(
     State(state): State<AppState>,
+    ctx: UserContext,
     mut multipart: Multipart,
 ) -> Result<Json<CreateFileResponse>, AppError> {
     let mut path = None;
@@ -77,8 +100,8 @@ async fn post_file(
 
     let content_hash: String = storage::write(&state.storage_dir, &content)?;
     tracing::info!("file stored: {} (hash: {})", path, content_hash);
-    let db = state.db;
-    let file_meta = db::put(&db, &path, content.len() as u64, &content_hash)?;
+    let db = TenantDb::new(state.db, ctx);
+    let file_meta = db.put(&path, content.len() as u64, &content_hash)?;
     tracing::info!("metadata saved: {} (version: {})", path, file_meta.version);
 
     Ok(Json(CreateFileResponse { file: file_meta }))
@@ -88,9 +111,10 @@ async fn post_file(
 async fn delete_file(
     State(state): State<AppState>,
     Path(path): Path<String>,
+    ctx: UserContext,
 ) -> Result<Json<DeleteFileResponse>, AppError> {
-    let db = state.db;
-    db::delete(&db, &path)?;
+    let db = TenantDb::new(state.db, ctx);
+    db.delete(&path)?;
     tracing::info!("file marked as deleted: {}", path);
     Ok(Json(DeleteFileResponse {}))
 }
@@ -99,10 +123,11 @@ async fn delete_file(
 async fn get_file(
     State(state): State<AppState>,
     Path(path): Path<String>,
+    ctx: UserContext,
     request: Request,
 ) -> Result<impl IntoResponse, AppError> {
-    let db: Arc<Database> = state.db;
-    let file_meta = db::get(&db, &path)?;
+    let db = TenantDb::new(state.db, ctx);
+    let file_meta = db.get(&path)?;
     let Some(file_meta) = file_meta else {
         tracing::warn!("metadata not found: {}", path);
         return Err(AppError(
@@ -123,9 +148,11 @@ async fn get_file(
 
 async fn create_upload(
     State(state): State<AppState>,
+    ctx: UserContext,
     extract::Json(body): extract::Json<InitUploadRequest>,
 ) -> Result<Json<InitUploadResponse>, AppError> {
-    let upload = db_upload::create(&state.db, body)?;
+    let db = TenantUploadDb::new(state.db, ctx);
+    let upload = db.create(body)?;
     let staging_dir = std::path::Path::new(&state.staging_dir).join(&upload.upload_id);
     std::fs::create_dir_all(staging_dir)?;
     Ok(Json(InitUploadResponse {
@@ -136,9 +163,11 @@ async fn create_upload(
 async fn replace_chunk(
     State(state): State<AppState>,
     extract::Path((upload_id, index)): Path<(String, u32)>,
+    ctx: UserContext,
     body: body::Bytes,
 ) -> Result<Json<ReplaceChunkResponse>, AppError> {
-    let upload = db_upload::get(&state.db, &upload_id)?;
+    let db = TenantUploadDb::new(state.db, ctx);
+    let upload = db.get(&upload_id)?;
     let Some(upload) = upload else {
         return Err(AppError(
             anyhow::anyhow!("upload not found"),
@@ -154,15 +183,17 @@ async fn replace_chunk(
     let staging_dir = std::path::Path::new(&state.staging_dir).join(&upload_id);
     let chunk_path = staging_dir.join(index.to_string());
     std::fs::write(chunk_path, body)?;
-    db_upload::add_chunk(&state.db, upload_id.as_str(), index)?;
+    db.add_chunk(&upload_id, index)?;
     Ok(Json(ReplaceChunkResponse { chunk_index: index }))
 }
 
 async fn get_upload(
     State(state): State<AppState>,
     extract::Path(upload_id): Path<String>,
+    ctx: UserContext,
 ) -> Result<Json<GetUploadResponse>, AppError> {
-    let upload = db_upload::get(&state.db, &upload_id)?;
+    let db = TenantUploadDb::new(state.db, ctx);
+    let upload = db.get(&upload_id)?;
     let Some(upload) = upload else {
         return Err(AppError(
             anyhow::anyhow!("not found"),
@@ -175,8 +206,10 @@ async fn get_upload(
 async fn finalize_upload(
     State(state): State<AppState>,
     extract::Path(upload_id): Path<String>,
+    ctx: UserContext,
 ) -> Result<Json<FinalizeUploadResponse>, AppError> {
-    let upload = db_upload::get(&state.db, &upload_id)?;
+    let upload_db: TenantUploadDb = TenantUploadDb::new(state.db.clone(), ctx.clone());
+    let upload = upload_db.get(&upload_id)?;
     let Some(upload) = upload else {
         return Err(AppError(
             anyhow::anyhow!("not found"),
@@ -209,13 +242,9 @@ async fn finalize_upload(
             StatusCode::INTERNAL_SERVER_ERROR,
         ));
     }
-    let file = db::put(
-        &state.db,
-        &upload.path,
-        upload.total_size,
-        &upload.total_hash,
-    )?;
-    db_upload::delete(&state.db, &upload_id)?;
+    let db = TenantDb::new(state.db, ctx);
+    let file = db.put(&upload.path, upload.total_size, &upload.total_hash)?;
+    upload_db.delete(&upload_id)?;
     std::fs::remove_dir_all(staging_dir)?;
     Ok(Json(FinalizeUploadResponse { file }))
 }
@@ -227,9 +256,6 @@ async fn get_health() -> Result<Json<GetHealthResponse>, AppError> {
     }))
 }
 
-#[derive(Clone)]
-struct AuthGranted;
-
 async fn bearer_auth_layer(
     State(state): State<AppState>,
     mut request: Request,
@@ -239,7 +265,10 @@ async fn bearer_auth_layer(
         && auth_header.to_str().unwrap() == format!("Bearer {}", state.token)
     {
         tracing::trace!("bearer token valid");
-        request.extensions_mut().insert(AuthGranted);
+        request.extensions_mut().insert(UserContext {
+            tenant_id: state.default_tenant_id,
+            user_id: state.default_user_id,
+        });
     }
     next.run(request).await
 }
@@ -254,13 +283,16 @@ async fn cookie_auth_layer(
         && crate::ui::verify_session_cookie(cookie_str, &state.token)
     {
         tracing::trace!("session cookie valid");
-        request.extensions_mut().insert(AuthGranted);
+        request.extensions_mut().insert(UserContext {
+            tenant_id: state.default_tenant_id,
+            user_id: state.default_user_id,
+        });
     }
     next.run(request).await
 }
 
 async fn require_auth_layer(request: Request, next: Next) -> Result<Response, StatusCode> {
-    if request.extensions().get::<AuthGranted>().is_some() {
+    if request.extensions().get::<UserContext>().is_some() {
         tracing::trace!("access granted");
         Ok(next.run(request).await)
     } else {
@@ -319,12 +351,18 @@ pub fn create_app(state: AppState) -> Router {
 
 pub fn bootstrap_app(config: ServerConfig) -> anyhow::Result<Router> {
     let db = db::open_db(&config.dbname)?;
+
+    // Run migrations
+    migrations::run_migrations(&db, &config.default_tenant_id, &config.default_user_id)?;
+
     let db = Arc::new(db);
     let state = AppState {
         db,
         storage_dir: config.storage_dir,
         staging_dir: config.staging_dir,
         token: config.token,
+        default_tenant_id: config.default_tenant_id,
+        default_user_id: config.default_user_id,
     };
     let app = create_app(state);
     Ok(app)

--- a/crates/cloudsync-server/src/auth.rs
+++ b/crates/cloudsync-server/src/auth.rs
@@ -1,0 +1,5 @@
+#[derive(Clone)]
+pub struct UserContext {
+    pub tenant_id: String,
+    pub user_id: String,
+}

--- a/crates/cloudsync-server/src/cli.rs
+++ b/crates/cloudsync-server/src/cli.rs
@@ -22,4 +22,8 @@ pub struct Args {
     pub staging_dir: String,
     #[arg(long, env = "CLOUDSYNC_DBNAME", default_value = "data.redb")]
     pub dbname: String,
+    #[arg(long, env = "CLOUDSYNC_DEFAULT_TENANT_ID", default_value = "tenant")]
+    pub default_tenant_id: String,
+    #[arg(long, env = "CLOUDSYNC_DEFAULT_USER_ID", default_value = "user")]
+    pub default_user_id: String,
 }

--- a/crates/cloudsync-server/src/cli.rs
+++ b/crates/cloudsync-server/src/cli.rs
@@ -22,8 +22,16 @@ pub struct Args {
     pub staging_dir: String,
     #[arg(long, env = "CLOUDSYNC_DBNAME", default_value = "data.redb")]
     pub dbname: String,
-    #[arg(long, env = "CLOUDSYNC_DEFAULT_TENANT_ID", default_value = "tenant")]
+    #[arg(
+        long,
+        env = "CLOUDSYNC_DEFAULT_TENANT_ID",
+        default_value = "default-tenant"
+    )]
     pub default_tenant_id: String,
-    #[arg(long, env = "CLOUDSYNC_DEFAULT_USER_ID", default_value = "user")]
+    #[arg(
+        long,
+        env = "CLOUDSYNC_DEFAULT_USER_ID",
+        default_value = "default-user"
+    )]
     pub default_user_id: String,
 }

--- a/crates/cloudsync-server/src/config.rs
+++ b/crates/cloudsync-server/src/config.rs
@@ -3,4 +3,6 @@ pub struct ServerConfig {
     pub staging_dir: String,
     pub token: String,
     pub dbname: String,
+    pub default_tenant_id: String,
+    pub default_user_id: String,
 }

--- a/crates/cloudsync-server/src/db.rs
+++ b/crates/cloudsync-server/src/db.rs
@@ -1,7 +1,9 @@
+use std::sync::Arc;
+
 use cloudsync_common::FileMeta;
 use redb::{Database, ReadableTable, TableDefinition};
 
-use crate::db_upload::TABLE_UPLOADS;
+use crate::{auth::UserContext, db_upload::TABLE_UPLOADS};
 
 pub const TABLE_FILES: TableDefinition<&str, &[u8]> = TableDefinition::new("files");
 
@@ -20,87 +22,113 @@ pub fn open_db(db_path: &str) -> anyhow::Result<Database> {
     Ok(db)
 }
 
-pub fn list(db: &Database) -> Result<Vec<FileMeta>, anyhow::Error> {
-    let tx = db.begin_read()?;
-    let table = tx.open_table(TABLE_FILES)?;
+pub struct TenantDb {
+    db: Arc<Database>,
+    user_context: UserContext,
+}
 
-    let mut file_metas: Vec<FileMeta> = Vec::new();
-    for entry in table.iter()? {
-        let (_, val) = entry?;
-        let bytes = val.value();
-        let file_meta = serde_json::from_slice::<FileMeta>(bytes)?;
-        if file_meta.is_deleted {
-            continue;
+impl TenantDb {
+    pub fn new(db: Arc<Database>, user_context: UserContext) -> Self {
+        TenantDb { db, user_context }
+    }
+
+    pub fn list(&self) -> Result<Vec<FileMeta>, anyhow::Error> {
+        let tx = self.db.begin_read()?;
+        let table = tx.open_table(TABLE_FILES)?;
+
+        let mut file_metas: Vec<FileMeta> = Vec::new();
+        for entry in table.iter()? {
+            let (key, val) = entry?;
+            if !key
+                .value()
+                .starts_with(&format!("{}\0", self.user_context.tenant_id))
+            {
+                continue;
+            }
+            let bytes = val.value();
+            let file_meta = serde_json::from_slice::<FileMeta>(bytes)?;
+            if file_meta.is_deleted {
+                continue;
+            }
+            file_metas.push(file_meta);
         }
-        file_metas.push(file_meta);
+
+        Ok(file_metas)
     }
 
-    Ok(file_metas)
-}
-
-pub fn get(db: &Database, path: &str) -> Result<Option<FileMeta>, anyhow::Error> {
-    let tx = db.begin_read()?;
-    let table = tx.open_table(TABLE_FILES)?;
-    let entry = table.get(path)?;
-    let Some(entry) = entry else {
-        return Ok(None);
-    };
-    let bytes = entry.value();
-    let file_meta = serde_json::from_slice::<FileMeta>(bytes)?;
-    Ok(Some(file_meta))
-}
-
-pub fn put(db: &Database, path: &str, size: u64, content_hash: &str) -> anyhow::Result<FileMeta> {
-    let tx = db.begin_read()?;
-    let table = tx.open_table(TABLE_FILES)?;
-    let entry = table.get(path)?;
-
-    let mut file_meta = FileMeta {
-        path: path.to_string(),
-        size,
-        content_hash: content_hash.to_string(),
-        version: 1,
-        is_deleted: false,
-        created_at: chrono::Utc::now(),
-        modified_at: chrono::Utc::now(),
-    };
-
-    if let Some(entry) = entry {
+    pub fn get(&self, path: &str) -> Result<Option<FileMeta>, anyhow::Error> {
+        let tx = self.db.begin_read()?;
+        let table = tx.open_table(TABLE_FILES)?;
+        let keyed_path = self.make_key(path);
+        let entry = table.get(keyed_path.as_str())?;
+        let Some(entry) = entry else {
+            return Ok(None);
+        };
         let bytes = entry.value();
-        let file_meta_raw = serde_json::from_slice::<FileMeta>(bytes)?;
-        file_meta.version = file_meta_raw.version + 1;
-        file_meta.created_at = file_meta_raw.created_at;
+        let file_meta = serde_json::from_slice::<FileMeta>(bytes)?;
+        Ok(Some(file_meta))
     }
-    drop(table);
 
-    let tx = db.begin_write()?;
-    {
-        let mut table = tx.open_table(TABLE_FILES)?;
-        let bytes = serde_json::to_vec(&file_meta)?;
-        table.insert(path, bytes.as_slice())?;
+    pub fn put(&self, path: &str, size: u64, content_hash: &str) -> anyhow::Result<FileMeta> {
+        let tx = self.db.begin_read()?;
+        let table = tx.open_table(TABLE_FILES)?;
+        let keyed_path = self.make_key(path);
+        let entry = table.get(keyed_path.as_str())?;
+
+        let mut file_meta = FileMeta {
+            path: path.to_string(),
+            size,
+            content_hash: content_hash.to_string(),
+            version: 1,
+            is_deleted: false,
+            created_at: chrono::Utc::now(),
+            modified_at: chrono::Utc::now(),
+            tenant_id: self.user_context.tenant_id.clone(),
+            user_id: self.user_context.user_id.clone(),
+        };
+
+        if let Some(entry) = entry {
+            let bytes = entry.value();
+            let file_meta_raw = serde_json::from_slice::<FileMeta>(bytes)?;
+            file_meta.version = file_meta_raw.version + 1;
+            file_meta.created_at = file_meta_raw.created_at;
+        }
+        drop(table);
+
+        let tx = self.db.begin_write()?;
+        {
+            let mut table = tx.open_table(TABLE_FILES)?;
+            let bytes = serde_json::to_vec(&file_meta)?;
+            table.insert(keyed_path.as_str(), bytes.as_slice())?;
+        }
+        tx.commit()?;
+        Ok(file_meta)
     }
-    tx.commit()?;
-    Ok(file_meta)
-}
 
-pub fn delete(db: &Database, path: &str) -> anyhow::Result<()> {
-    let tx = db.begin_read()?;
-    let table = tx.open_table(TABLE_FILES)?;
-    let entry = table.get(path)?;
-    let Some(entry) = entry else { return Ok(()) };
-    let bytes = entry.value();
-    let mut file_meta = serde_json::from_slice::<FileMeta>(bytes)?;
-    file_meta.is_deleted = true;
-    drop(table);
+    pub fn delete(&self, path: &str) -> anyhow::Result<()> {
+        let tx = self.db.begin_read()?;
+        let table = tx.open_table(TABLE_FILES)?;
+        let keyed_path = self.make_key(path);
+        let entry = table.get(keyed_path.as_str())?;
+        let Some(entry) = entry else { return Ok(()) };
+        let bytes = entry.value();
+        let mut file_meta = serde_json::from_slice::<FileMeta>(bytes)?;
+        file_meta.is_deleted = true;
+        drop(table);
 
-    let tx = db.begin_write()?;
-    {
-        let mut table = tx.open_table(TABLE_FILES)?;
-        let bytes = serde_json::to_vec(&file_meta)?;
-        table.insert(path, bytes.as_slice())?;
+        let tx = self.db.begin_write()?;
+        {
+            let mut table = tx.open_table(TABLE_FILES)?;
+            let bytes = serde_json::to_vec(&file_meta)?;
+            table.insert(keyed_path.as_str(), bytes.as_slice())?;
+        }
+        tx.commit()?;
+        Ok(())
     }
-    tx.commit()?;
-    Ok(())
+
+    fn make_key(&self, path: &str) -> String {
+        format!("{}\0{}", self.user_context.tenant_id, path)
+    }
 }
 
 #[cfg(test)]
@@ -120,15 +148,26 @@ mod test {
         (dir, db)
     }
 
+    fn test_tenant(db: Arc<Database>, tenant_id: Option<String>) -> TenantDb {
+        TenantDb {
+            db,
+            user_context: UserContext {
+                tenant_id: tenant_id.unwrap_or("tenant1".to_string()),
+                user_id: "user1".to_string(),
+            },
+        }
+    }
+
     #[test]
     fn test_full_lifecycle() {
         let (_dir, db) = test_db();
+        let db = test_tenant(Arc::new(db), None);
 
         let path = "somepath/test.txt";
         let bytes = b"hello world";
         let hash = hash_bytes(bytes);
         let size = bytes.len() as u64;
-        let file_meta = put(&db, path, size, &hash).unwrap();
+        let file_meta = db.put(path, size, &hash).unwrap();
 
         assert_eq!(file_meta.path, path);
         assert_eq!(file_meta.content_hash, hash);
@@ -136,36 +175,68 @@ mod test {
         assert_eq!(file_meta.version, 1);
         assert_eq!(file_meta.is_deleted, false);
 
-        let file_meta = get(&db, path).unwrap().unwrap();
+        let file_meta = db.get(path).unwrap().unwrap();
         assert_eq!(file_meta.path, path);
         assert_eq!(file_meta.content_hash, hash);
         assert_eq!(file_meta.size, size);
         assert_eq!(file_meta.version, 1);
         assert_eq!(file_meta.is_deleted, false);
 
-        let file_meta = put(&db, path, size, &hash).unwrap();
+        let file_meta = db.put(path, size, &hash).unwrap();
         assert_eq!(file_meta.version, 2);
 
         let path = "somepath/test2.txt";
         let bytes = b"hello world";
         let hash = hash_bytes(bytes);
         let size = bytes.len() as u64;
-        put(&db, path, size, &hash).unwrap();
-        let file_metas = list(&db).unwrap();
+        db.put(path, size, &hash).unwrap();
+        let file_metas = db.list().unwrap();
         assert_eq!(file_metas.len(), 2);
 
-        delete(&db, path).unwrap();
+        db.delete(path).unwrap();
 
-        let file_metas = list(&db).unwrap();
+        let file_metas = db.list().unwrap();
         assert_eq!(file_metas.len(), 1);
     }
 
     #[test]
     fn test_get_not_exist() {
         let (_dir, db) = test_db();
+        let db = test_tenant(Arc::new(db), None);
 
-        let file_meta = get(&db, "notexist").unwrap();
+        let file_meta = db.get("notexist").unwrap();
 
         assert!(file_meta.is_none());
+    }
+
+    #[test]
+    fn test_tenanta_cannot_see_tenantb() {
+        let (_dir, db) = test_db();
+        let tenanta_name = "tenanta".to_string();
+        let tenantb_name = "tenantb".to_string();
+        let arc_db = Arc::new(db);
+        let tenanta = test_tenant(Arc::clone(&arc_db), Some(tenanta_name.clone()));
+        let tenantb = test_tenant(arc_db, Some(tenantb_name.clone()));
+
+        let path = "tenanta/test.txt";
+        let bytes = b"hello world";
+        let hash = hash_bytes(bytes);
+        let size = bytes.len() as u64;
+        let file_metaa = tenanta.put(path, size, &hash).unwrap();
+        assert_eq!(tenanta_name, file_metaa.tenant_id);
+
+        let path = "tenantb/test.txt";
+        let bytes = b"hello world";
+        let hash = hash_bytes(bytes);
+        let size = bytes.len() as u64;
+        let file_metab = tenantb.put(path, size, &hash).unwrap();
+        assert_eq!(tenantb_name, file_metab.tenant_id);
+
+        let patha = tenanta.get("tenanta/test.txt").unwrap();
+        assert!(patha.is_some());
+        let pathb = tenanta.get("tenantb/test.txt").unwrap();
+        assert!(pathb.is_none());
+        let patha = tenantb.get("tenanta/test.txt").unwrap();
+        assert!(patha.is_none());
     }
 }

--- a/crates/cloudsync-server/src/db_upload.rs
+++ b/crates/cloudsync-server/src/db_upload.rs
@@ -1,83 +1,120 @@
+use std::sync::Arc;
+
 use cloudsync_common::{InitUploadRequest, Upload};
 use redb::{Database, ReadableTable, TableDefinition};
 
+use crate::auth::UserContext;
+
 pub const TABLE_UPLOADS: TableDefinition<&str, &[u8]> = TableDefinition::new("uploads");
 
-pub fn get(db: &Database, upload_id: &str) -> Result<Option<Upload>, anyhow::Error> {
-    let tx = db.begin_read()?;
-    let table = tx.open_table(TABLE_UPLOADS)?;
-    let entry = table.get(upload_id)?;
-    let Some(entry) = entry else {
-        return Ok(None);
-    };
-    let bytes = entry.value();
-    let file_meta = serde_json::from_slice::<Upload>(bytes)?;
-    Ok(Some(file_meta))
+pub struct TenantUploadDb {
+    db: Arc<Database>,
+    user_context: UserContext,
 }
 
-pub fn create(db: &Database, upload_request: InitUploadRequest) -> anyhow::Result<Upload> {
-    let upload_id = nanoid::nanoid!();
-    let upload = Upload {
-        upload_id: upload_id.clone(),
-        path: upload_request.path,
-        total_size: upload_request.total_size,
-        total_hash: upload_request.total_hash,
-        chunk_count: upload_request.chunk_count,
-        chunks_received: vec![],
-        created_at: chrono::Utc::now(),
-        modified_at: chrono::Utc::now(),
-    };
-
-    let tx = db.begin_write()?;
-    {
-        let mut table = tx.open_table(TABLE_UPLOADS)?;
-        let bytes = serde_json::to_vec(&upload)?;
-        table.insert(upload_id.as_str(), bytes.as_slice())?;
+impl TenantUploadDb {
+    pub fn new(db: Arc<Database>, user_context: UserContext) -> Self {
+        TenantUploadDb { db, user_context }
     }
-    tx.commit()?;
-    Ok(upload)
-}
 
-pub fn add_chunk(db: &Database, upload_id: &str, chunk_index: u32) -> anyhow::Result<Upload> {
-    // get upload
-    let tx = db.begin_write()?;
-    let mut upload = {
+    pub fn get(&self, upload_id: &str) -> Result<Option<Upload>, anyhow::Error> {
+        let tx = self.db.begin_read()?;
         let table = tx.open_table(TABLE_UPLOADS)?;
         let entry = table.get(upload_id)?;
-
         let Some(entry) = entry else {
-            anyhow::bail!("upload not found: {}", upload_id);
+            return Ok(None);
+        };
+        let bytes = entry.value();
+        let file_meta = serde_json::from_slice::<Upload>(bytes)?;
+        if file_meta.tenant_id != self.user_context.tenant_id {
+            return Ok(None);
+        }
+        Ok(Some(file_meta))
+    }
+
+    pub fn create(&self, upload_request: InitUploadRequest) -> anyhow::Result<Upload> {
+        let upload_id = nanoid::nanoid!();
+        let upload = Upload {
+            upload_id: upload_id.clone(),
+            path: upload_request.path,
+            total_size: upload_request.total_size,
+            total_hash: upload_request.total_hash,
+            chunk_count: upload_request.chunk_count,
+            chunks_received: vec![],
+            created_at: chrono::Utc::now(),
+            modified_at: chrono::Utc::now(),
+            tenant_id: self.user_context.tenant_id.clone(),
+            user_id: self.user_context.user_id.clone(),
         };
 
-        let bytes = entry.value();
-        serde_json::from_slice::<Upload>(bytes)?
-    };
-
-    if upload.chunks_received.contains(&chunk_index) {
-        return Ok(upload);
+        let tx = self.db.begin_write()?;
+        {
+            let mut table = tx.open_table(TABLE_UPLOADS)?;
+            let bytes = serde_json::to_vec(&upload)?;
+            table.insert(upload_id.as_str(), bytes.as_slice())?;
+        }
+        tx.commit()?;
+        Ok(upload)
     }
 
-    upload.chunks_received.push(chunk_index);
-    upload.modified_at = chrono::Utc::now();
+    pub fn add_chunk(&self, upload_id: &str, chunk_index: u32) -> anyhow::Result<Upload> {
+        // get upload
+        let tx = self.db.begin_write()?;
+        let mut upload = {
+            let table = tx.open_table(TABLE_UPLOADS)?;
+            let entry: Option<redb::AccessGuard<'_, &[u8]>> = table.get(upload_id)?;
 
-    {
-        let mut table = tx.open_table(TABLE_UPLOADS)?;
-        let bytes = serde_json::to_vec(&upload)?;
-        table.insert(upload_id, bytes.as_slice())?;
+            let Some(entry) = entry else {
+                anyhow::bail!("upload not found: {}", upload_id);
+            };
+
+            let bytes = entry.value();
+            serde_json::from_slice::<Upload>(bytes)?
+        };
+
+        if upload.tenant_id != self.user_context.tenant_id {
+            anyhow::bail!("upload not found: {}", upload_id);
+        }
+        if upload.chunks_received.contains(&chunk_index) {
+            return Ok(upload);
+        }
+
+        upload.chunks_received.push(chunk_index);
+        upload.modified_at = chrono::Utc::now();
+
+        {
+            let mut table = tx.open_table(TABLE_UPLOADS)?;
+            let bytes = serde_json::to_vec(&upload)?;
+            table.insert(upload_id, bytes.as_slice())?;
+        }
+        tx.commit()?;
+
+        Ok(upload)
     }
-    tx.commit()?;
 
-    Ok(upload)
-}
+    pub fn delete(&self, upload_id: &str) -> anyhow::Result<()> {
+        let tx = self.db.begin_write()?;
+        {
+            let mut table = tx.open_table(TABLE_UPLOADS)?;
 
-pub fn delete(db: &Database, upload_id: &str) -> anyhow::Result<()> {
-    let tx = db.begin_write()?;
-    {
-        let mut table = tx.open_table(TABLE_UPLOADS)?;
-        table.remove(upload_id)?;
+            let is_owned = {
+                let entry: Option<redb::AccessGuard<'_, &[u8]>> = table.get(upload_id)?;
+                if let Some(entry) = entry {
+                    let bytes = entry.value();
+                    let file_meta = serde_json::from_slice::<Upload>(bytes)?;
+                    file_meta.tenant_id == self.user_context.tenant_id
+                } else {
+                    return Ok(());
+                }
+            };
+            if !is_owned {
+                anyhow::bail!("upload not found: {}", upload_id);
+            }
+            table.remove(upload_id)?;
+        }
+        tx.commit()?;
+        Ok(())
     }
-    tx.commit()?;
-    Ok(())
 }
 
 #[cfg(test)]
@@ -86,13 +123,20 @@ mod test {
 
     use tempfile::TempDir;
 
-    fn test_db() -> (TempDir, Database) {
+    fn test_db() -> (TempDir, TenantUploadDb) {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("test.redb");
         let db = redb::Database::create(&path).unwrap();
         let tx = db.begin_write().unwrap();
         tx.open_table(TABLE_UPLOADS).unwrap();
         tx.commit().unwrap();
+        let db = TenantUploadDb {
+            db: Arc::new(db),
+            user_context: UserContext {
+                tenant_id: "tenant1".to_string(),
+                user_id: "user1".to_string(),
+            },
+        };
         (dir, db)
     }
 
@@ -100,32 +144,30 @@ mod test {
     fn test_full_lifecycle() {
         let (_dir, db) = test_db();
 
-        let upload = create(
-            &db,
-            InitUploadRequest {
+        let upload = db
+            .create(InitUploadRequest {
                 path: "file0".to_string(),
                 total_size: 10,
                 total_hash: "testhash".to_string(),
                 chunk_count: 100,
-            },
-        )
-        .unwrap();
+            })
+            .unwrap();
 
         assert_eq!(upload.chunks_received.len(), 0);
 
-        let upload = add_chunk(&db, &upload.upload_id, 0).unwrap();
-        let upload = add_chunk(&db, &upload.upload_id, 3).unwrap();
+        let upload = db.add_chunk(&upload.upload_id, 0).unwrap();
+        let upload = db.add_chunk(&upload.upload_id, 3).unwrap();
 
         assert_eq!(upload.chunks_received.len(), 2);
         assert!(upload.chunks_received.iter().any(|ch| *ch == 0));
         assert!(upload.chunks_received.iter().any(|ch| *ch == 3));
 
-        let upload_get = get(&db, &upload.upload_id).unwrap();
+        let upload_get = db.get(&upload.upload_id).unwrap();
         assert!(upload_get.is_some());
 
-        delete(&db, &upload.upload_id).unwrap();
+        db.delete(&upload.upload_id).unwrap();
 
-        let upload_get = get(&db, &upload.upload_id).unwrap();
+        let upload_get = db.get(&upload.upload_id).unwrap();
         assert!(upload_get.is_none());
     }
 
@@ -133,7 +175,7 @@ mod test {
     fn test_get_not_exist() {
         let (_dir, db) = test_db();
 
-        let file_meta = get(&db, "notexist").unwrap();
+        let file_meta = db.get("notexist").unwrap();
 
         assert!(file_meta.is_none());
     }

--- a/crates/cloudsync-server/src/lib.rs
+++ b/crates/cloudsync-server/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod app;
+mod auth;
 pub mod config;
 mod db;
 mod db_upload;
 mod storage;
 mod ui;
+
+mod migrations;

--- a/crates/cloudsync-server/src/main.rs
+++ b/crates/cloudsync-server/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 
 mod cli;
+
 use cloudsync_server::app;
 use cloudsync_server::config;
 
@@ -15,7 +16,11 @@ async fn main() -> anyhow::Result<()> {
         staging_dir: args.staging_dir,
         token: args.token,
         dbname: args.dbname,
+        default_tenant_id: args.default_tenant_id,
+        default_user_id: args.default_user_id,
     };
+
+    // Start server
     let app = app::bootstrap_app(config).unwrap();
     let listener = tokio::net::TcpListener::bind(format!("{}:{}", args.host, args.port))
         .await

--- a/crates/cloudsync-server/src/migrations/m001_tenant_namespace.rs
+++ b/crates/cloudsync-server/src/migrations/m001_tenant_namespace.rs
@@ -1,0 +1,52 @@
+use cloudsync_common::FileMeta;
+use redb::{Database, ReadableTable};
+
+use crate::db::TABLE_FILES;
+
+use super::meta;
+
+pub fn migrate(
+    db: &Database,
+    default_tenant_id: &str,
+    default_user_id: &str,
+) -> anyhow::Result<()> {
+    let meta = meta::get(db)?;
+    if meta.schema_version >= 1 {
+        return Ok(());
+    }
+
+    // Read all file_metas
+    let tx = db.begin_read()?;
+    let table = tx.open_table(TABLE_FILES)?;
+    let mut file_metas: Vec<FileMeta> = Vec::new();
+    for entry in table.iter()? {
+        let (key, val) = entry?;
+        let key = key.value().to_string();
+        if key.contains("\0") {
+            continue;
+        }
+        let bytes = val.value().to_vec();
+        let file_meta = serde_json::from_slice::<FileMeta>(bytes.as_slice())?;
+        file_metas.push(file_meta);
+    }
+    drop(tx);
+
+    // Transform all file_metas
+    let tx = db.begin_write()?;
+    {
+        let mut table = tx.open_table(TABLE_FILES)?;
+        for mut file_meta in file_metas {
+            let new_key = format!("{}\0{}", default_tenant_id, file_meta.path);
+            file_meta.tenant_id = default_tenant_id.to_string();
+            file_meta.user_id = default_user_id.to_string();
+            let bytes = serde_json::to_vec(&file_meta)?;
+            table.insert(new_key.as_str(), bytes.as_slice())?;
+            table.remove(file_meta.path.as_str())?;
+        }
+    }
+    tx.commit()?;
+
+    meta::inc(db)?;
+
+    Ok(())
+}

--- a/crates/cloudsync-server/src/migrations/meta.rs
+++ b/crates/cloudsync-server/src/migrations/meta.rs
@@ -1,0 +1,74 @@
+use redb::{Database, TableDefinition};
+use serde::{Deserialize, Serialize};
+
+pub const TABLE_META: TableDefinition<&str, &[u8]> = TableDefinition::new("meta");
+
+const META_KEY: &str = "SCHEMA_VERSION";
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Meta {
+    pub schema_version: u32,
+}
+
+pub fn get(db: &Database) -> Result<Meta, anyhow::Error> {
+    let tx = db.begin_read()?;
+    let table = tx.open_table(TABLE_META)?;
+    let entry = table.get(META_KEY)?;
+    let Some(entry) = entry else {
+        return Ok(Meta { schema_version: 0 });
+    };
+    let bytes = entry.value();
+    let meta = serde_json::from_slice::<Meta>(bytes)?;
+    Ok(meta)
+}
+
+pub fn inc(db: &Database) -> anyhow::Result<()> {
+    let tx = db.begin_read()?;
+    let table = tx.open_table(TABLE_META)?;
+    let entry = table.get(META_KEY)?;
+    let mut meta = match entry {
+        Some(entry) => serde_json::from_slice::<Meta>(entry.value())?,
+        None => Meta { schema_version: 0 },
+    };
+
+    let tx = db.begin_write()?;
+    {
+        let mut table = tx.open_table(TABLE_META)?;
+        meta.schema_version += 1;
+        let bytes = serde_json::to_vec(&meta)?;
+        table.insert(META_KEY, bytes.as_slice())?;
+    }
+    tx.commit()?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use tempfile::TempDir;
+
+    fn test_db() -> (TempDir, Database) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.redb");
+        let db = redb::Database::create(&path).unwrap();
+        let tx = db.begin_write().unwrap();
+        tx.open_table(TABLE_META).unwrap();
+        tx.commit().unwrap();
+        (dir, db)
+    }
+
+    #[test]
+    fn test_full_lifecycle() {
+        let (_dir, db) = test_db();
+
+        let meta = get(&db).unwrap();
+        assert_eq!(0, meta.schema_version);
+
+        inc(&db).unwrap();
+        inc(&db).unwrap();
+        let meta = get(&db).unwrap();
+        assert_eq!(2, meta.schema_version);
+    }
+}

--- a/crates/cloudsync-server/src/migrations/mod.rs
+++ b/crates/cloudsync-server/src/migrations/mod.rs
@@ -1,0 +1,94 @@
+use redb::Database;
+
+use crate::migrations::meta::TABLE_META;
+
+mod m001_tenant_namespace;
+mod meta;
+
+pub fn run_migrations(
+    db: &Database,
+    default_tenant_id: &str,
+    default_user_id: &str,
+) -> anyhow::Result<()> {
+    let tx = db.begin_write()?;
+    {
+        tx.open_table(TABLE_META)?;
+    }
+    tx.commit()?;
+    m001_tenant_namespace::migrate(db, default_tenant_id, default_user_id)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use cloudsync_common::FileMeta;
+
+    use crate::{db::TABLE_FILES, migrations::meta::TABLE_META};
+
+    use super::*;
+
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    fn test_db() -> (TempDir, Database) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.redb");
+        let db = redb::Database::create(&path).unwrap();
+        let tx = db.begin_write().unwrap();
+        tx.open_table(TABLE_META).unwrap();
+        tx.commit().unwrap();
+        (dir, db)
+    }
+
+    #[test]
+    fn test_migration() {
+        let (_dir, db) = test_db();
+        let file_metas = ["file1.txt", "file2.txt"].map(|path| FileMeta {
+            tenant_id: "".to_string(),
+            user_id: "".to_string(),
+            path: path.to_string(),
+            version: 0,
+            created_at: Utc::now(),
+            is_deleted: false,
+            modified_at: Utc::now(),
+            size: 0,
+            content_hash: "".to_string(),
+        });
+
+        file_metas.iter().for_each(|fm| {
+            let tx = db.begin_write().unwrap();
+            {
+                let mut table = tx.open_table(TABLE_FILES).unwrap();
+                let bytes = serde_json::to_vec(fm).unwrap();
+                table.insert(fm.path.as_str(), bytes.as_slice()).unwrap();
+            }
+            tx.commit().unwrap();
+        });
+
+        // Execute
+        run_migrations(&db, "tenant1", "user1").unwrap();
+
+        test_migrated_path(&db, "file1.txt");
+        test_migrated_path(&db, "file2.txt");
+
+        let meta = meta::get(&db).unwrap();
+        assert_eq!(meta.schema_version, 1);
+    }
+
+    fn test_migrated_path(db: &Database, old_path: &str) {
+        let tx = db.begin_read().unwrap();
+        let table = tx.open_table(TABLE_FILES).unwrap();
+        let new_key = format!("tenant1\0{}", old_path);
+        let entry = table.get(new_key.as_str()).unwrap();
+        let Some(entry) = entry else {
+            panic!("migrated file_meta not found");
+        };
+        let bytes = entry.value();
+        let file_meta = serde_json::from_slice::<FileMeta>(bytes).unwrap();
+        assert_eq!(file_meta.tenant_id, "tenant1");
+        assert_eq!(file_meta.user_id, "user1");
+        assert_eq!(file_meta.path, old_path);
+        let entry = table.get(old_path).unwrap();
+        assert!(entry.is_none());
+    }
+}

--- a/crates/cloudsync-server/src/ui.rs
+++ b/crates/cloudsync-server/src/ui.rs
@@ -11,8 +11,8 @@ use hmac::{Hmac, Mac};
 use rust_embed::RustEmbed;
 use sha2::Sha256;
 
-use crate::app::AppState;
-use crate::db;
+use crate::auth::UserContext;
+use crate::{app::AppState, db::TenantDb};
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -186,7 +186,14 @@ pub async fn browse(
     }
 
     let prefix = query.prefix.unwrap_or_default();
-    let all_files = match db::list(&state.db) {
+    let db = TenantDb::new(
+        state.db.clone(),
+        UserContext {
+            tenant_id: state.default_tenant_id.clone(),
+            user_id: state.default_user_id.clone(),
+        },
+    );
+    let all_files = match db.list() {
         Ok(f) => f,
         Err(_) => {
             return (StatusCode::INTERNAL_SERVER_ERROR, "Failed to list files").into_response();
@@ -326,6 +333,8 @@ mod tests {
             is_deleted: false,
             created_at: chrono::Utc::now(),
             modified_at: chrono::Utc::now(),
+            user_id: "user".to_string(),
+            tenant_id: "tenant".to_string(),
         }
     }
 }

--- a/crates/cloudsync-server/tests/integration_test.rs
+++ b/crates/cloudsync-server/tests/integration_test.rs
@@ -23,6 +23,8 @@ async fn test_range_download() {
         staging_dir: staging_dir.to_str().unwrap().to_string(),
         token: token.to_string(),
         dbname: dbname.to_string(),
+        default_tenant_id: "tenant".to_string(),
+        default_user_id: "user".to_string(),
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -75,6 +77,8 @@ async fn test_chunked_upload() {
         staging_dir: staging_dir.to_str().unwrap().to_string(),
         token: token.to_string(),
         dbname: dbname.to_string(),
+        default_tenant_id: "tenant".to_string(),
+        default_user_id: "user".to_string(),
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
       - CLOUDSYNC_STAGING_DIR=/data/staging
       - CLOUDSYNC_DBNAME=/data/data.redb
       - CLOUDSYNC_HOST=0.0.0.0
+      # Static token auth: maps all requests to this tenant/user.
+      # Not needed when OIDC is configured (users get their own tenants).
+      - CLOUDSYNC_DEFAULT_TENANT_ID=${CLOUDSYNC_DEFAULT_TENANT_ID:-default-tenant}
+      - CLOUDSYNC_DEFAULT_USER_ID=${CLOUDSYNC_DEFAULT_USER_ID:-default-user}
       - RUST_LOG=cloudsync_server=info
     restart: unless-stopped
 

--- a/docs/plan-oidc.md
+++ b/docs/plan-oidc.md
@@ -1,0 +1,276 @@
+# OIDC Authentication for CloudSync
+
+## Context
+
+CloudSync currently uses a single static token shared by all users. There is no user identity, no per-user isolation, and no way to restrict individual access. This plan introduces OIDC authentication via Keycloak, a user registry with auto-provisioning, and tenant-scoped file namespacing — transforming CloudSync from a single-user tool into a proper multi-user, multi-tenant system while keeping the static token as a migration fallback.
+
+### Tenancy model
+
+All data is scoped to a tenant from the start. `tenant_id` and `user_id` are always separate values — even when there's only one user per tenant, the tenant gets its own generated ID (nanoid). This means:
+- Code never assumes `tenant_id == user_id`
+- Adding a second user to an existing tenant is just an insert into the users table
+- The user→tenant mapping lives in `UserRecord` and is the single source of truth
+
+### Keycloak as the gatekeeper
+
+Keycloak has self-registration **disabled by default**. Only users manually created by the admin (or approved via the "First Broker Login" flow for federated providers) can authenticate. This means Keycloak itself acts as the allowlist — if someone can get a JWT, they've been explicitly approved.
+
+CloudSync auto-provisions a `UserRecord` (with a new tenant) on first login from a valid JWT. The `TABLE_USERS` table is not an allowlist — it's a **user→tenant mapping** and a **kill switch** (`is_active`) independent of Keycloak.
+
+User control flow:
+1. Admin creates user in Keycloak admin console (or approves federated login)
+2. User authenticates → gets JWT with `sub` (opaque UUID, no PII)
+3. CloudSync sees valid JWT, auto-creates `UserRecord { user_id: sub, tenant_id: <new nanoid>, is_active: true }`
+4. To revoke: set `is_active = false` in CloudSync (immediate) or delete the Keycloak account (permanent)
+5. To share a tenant: admin reassigns a user's `tenant_id` to an existing tenant via the admin API
+
+### Minimal PII
+
+CloudSync stores only:
+- `user_id` — the OIDC `sub` claim (opaque UUID, not PII)
+- `tenant_id` — generated nanoid
+- `is_active` — boolean
+
+No email, no display name, no profile data. If needed for UI display, read from JWT claims at request time. Keeps us out of GDPR/privacy concerns.
+
+---
+
+## Phase 1: `UserContext` + Tenant-Scoped DB Namespacing
+
+**Goal:** Replace unit-struct `AuthGranted` with a typed `UserContext { user_id, tenant_id }`. Scope all DB operations to a tenant. Migrate existing data. Static token still works — maps to a configurable default user/tenant.
+
+This is the riskiest structural change but requires no new dependencies and is fully testable with the existing static token.
+
+### Changes
+
+**`crates/cloudsync-common/src/lib.rs`** — Add `tenant_id: String` and `user_id: String` to `FileMeta` with `#[serde(default)]` for backward compat during migration.
+
+**`crates/cloudsync-common/src/upload.rs`** — Add `tenant_id: String` and `user_id: String` to `Upload` and `InitUploadRequest` (also `#[serde(default)]`).
+
+**`crates/cloudsync-server/src/app.rs`**:
+- Replace `struct AuthGranted;` (line 231) with:
+  ```rust
+  #[derive(Clone)]
+  pub struct UserContext {
+      pub user_id: String,
+      pub tenant_id: String,
+  }
+  ```
+- Add `default_user_id: String` and `default_tenant_id: String` to `AppState`
+- `bearer_auth_layer`: insert `UserContext { user_id: default_user_id, tenant_id: default_tenant_id }` instead of `AuthGranted`
+- `cookie_auth_layer`: same
+- `require_auth_layer`: check for `UserContext` instead of `AuthGranted`
+- All handlers (`list_files`, `post_file`, `delete_file`, `get_file`, `create_upload`, `replace_chunk`, `get_upload`, `finalize_upload`): extract `UserContext` from request extensions, pass `tenant_id` to DB functions
+
+**`crates/cloudsync-server/src/db.rs`** — Change DB key from `path` to `"{tenant_id}\0{path}"` (NUL separator):
+- All functions (`list`, `get`, `put`, `delete`) accept `tenant_id: &str`
+- `list` does prefix scan on `"{tenant_id}\0"` to return only that tenant's files
+- Add migration in `open_db`: detect old-style keys (no NUL), rewrite to `"{default_tenant_id}\0{path}"`. Track schema version in a `TABLE_META` table.
+
+**`crates/cloudsync-server/src/db_upload.rs`** — Store `tenant_id` and `user_id` in Upload value. Add ownership check on `get` (verify `tenant_id` matches).
+
+**`crates/cloudsync-server/src/config.rs`** — Add `default_user_id: String` and `default_tenant_id: String` to `ServerConfig`.
+
+**`crates/cloudsync-server/src/cli.rs`** — Add `--default-user-id` / `CLOUDSYNC_DEFAULT_USER_ID` (default: `"default"`) and `--default-tenant-id` / `CLOUDSYNC_DEFAULT_TENANT_ID` (default: `"default-tenant"`). Separate IDs from the start.
+
+**`crates/cloudsync-server/src/ui.rs`** — `browse` handler passes `default_tenant_id` to `db::list` (upgraded to real identity in Phase 4).
+
+### Content-addressable storage
+Stays global/shared. Dedup across tenants is a feature. The metadata layer (DB keys) provides tenant isolation. Blobs are just hashes — they don't leak ownership.
+
+### Testing
+- Existing tests pass (static token maps to default user/tenant)
+- New unit tests: composite-key CRUD, prefix-scan isolation between tenants, migration from old schema
+
+---
+
+## Phase 2: User Registry + Auto-Provisioning
+
+**Goal:** `TABLE_USERS` stores the user→tenant mapping. Auto-provision on first OIDC login. Admin API for managing users and tenant assignments. Default user seeded on first boot.
+
+Note: Keycloak controls who can authenticate (see "Keycloak as the gatekeeper" above). `TABLE_USERS` is not an allowlist — it's the registry that maps users to tenants and provides a kill switch.
+
+### Changes
+
+**`crates/cloudsync-server/src/db_users.rs`** (new) — `TABLE_USERS: TableDefinition<&str, &[u8]>`:
+```rust
+pub struct UserRecord {
+    pub user_id: String,
+    pub tenant_id: String,
+    pub is_active: bool,
+    pub created_at: DateTime<Utc>,
+}
+```
+CRUD: `list_users`, `get_user`, `create_user`, `deactivate_user`.
+
+**`crates/cloudsync-server/src/db.rs`** — Open `TABLE_USERS` in `open_db`. Seed default user with a separate `default_tenant_id` if table is empty.
+
+**`crates/cloudsync-server/src/app.rs`**:
+- Add `user_registry_layer` middleware: after auth layers, before `require_auth_layer`. Looks up `UserContext.user_id` in `TABLE_USERS`:
+  - **Found + active**: populate `UserContext.tenant_id` from the `UserRecord` (authoritative source)
+  - **Found + inactive**: return 403 (kill switch)
+  - **Not found**: auto-provision — create `UserRecord` with new `tenant_id` (nanoid), populate `UserContext`
+- Add admin API routes (gated by admin user_id check). These manage **tenant assignments**, not user identity (that's Keycloak's job):
+  - `GET /api/v1/admin/users` — list all users and their tenant assignments
+  - `PUT /api/v1/admin/users/{user_id}` — update user (reassign tenant, toggle active)
+  - `GET /api/v1/admin/tenants/{tenant_id}/users` — list users in a tenant
+
+**`crates/cloudsync-server/src/cli.rs`** — Add `--admin-user-id` / `CLOUDSYNC_ADMIN_USER_ID` (defaults to `default_user_id`).
+
+### Testing
+- Unit tests for `db_users.rs`
+- Integration test: deactivate a user, verify 403
+
+---
+
+## Phase 3: JWT Validation + OIDC Discovery (Server)
+
+**Goal:** Server validates JWT access tokens from Keycloak. Static token fallback remains. Server-only — client continues with static tokens.
+
+### Changes
+
+**`crates/cloudsync-server/src/oidc.rs`** (new):
+- `OidcValidator` struct: cached JWKS keys in `RwLock<HashMap<String, DecodingKey>>`, reqwest client
+- `discover(issuer_url)`: fetch `.well-known/openid-configuration`, extract `jwks_uri`, fetch JWKS
+- `validate_token(token) -> Result<Claims>`: decode JWT, validate `exp`/`iss`/`aud`, extract `sub`/`email`
+- JWKS refresh on `kid` miss (single retry)
+
+**`crates/cloudsync-server/src/app.rs`**:
+- Add `oidc: Option<Arc<OidcValidator>>` to `AppState`
+- `bearer_auth_layer`: try static token first (fast path), then JWT validation. On valid JWT, insert `UserContext { user_id: claims.sub, tenant_id: "" }` (placeholder — `user_registry_layer` from Phase 2 resolves the real `tenant_id` from the `UserRecord`)
+
+**`crates/cloudsync-server/src/config.rs`** — Add `oidc_issuer_url: Option<String>`, `oidc_audience: Option<String>`.
+
+**`crates/cloudsync-server/src/cli.rs`** — Add `--oidc-issuer-url` / `CLOUDSYNC_OIDC_ISSUER_URL`, `--oidc-audience` / `CLOUDSYNC_OIDC_AUDIENCE` (optional).
+
+**`crates/cloudsync-server/src/main.rs`** — If OIDC env vars set, call `OidcValidator::discover()` at startup.
+
+### New dependencies (server)
+- `jsonwebtoken = "9"` — JWT decoding/validation
+- `reqwest` (add to server runtime deps) — OIDC discovery, JWKS fetch
+
+### Testing
+- Unit test with locally-generated RS256 keypair + hand-crafted JWT
+- Integration test with mock JWKS endpoint
+- Verify static token still works alongside OIDC
+
+---
+
+## Phase 4: Web UI OIDC (Authorization Code + PKCE)
+
+**Goal:** Replace token login form with "Sign in with Keycloak" using Authorization Code + PKCE flow. Session cookies now carry user identity.
+
+### Changes
+
+**`crates/cloudsync-server/src/ui.rs`**:
+- Login page: if OIDC configured, show "Sign in" button → redirect to Keycloak authorize endpoint with `state` + PKCE `code_verifier` (stored in encrypted cookie or server-side map)
+- New `GET /auth/callback` handler: exchange code for tokens at Keycloak token endpoint, validate ID token, extract user identity
+- Session cookie format changes from `{hmac_sig}` to `{user_id}:{hmac(user_id, secret)}` — `cookie_auth_layer` extracts `user_id`, `user_registry_layer` resolves `tenant_id`
+- Fallback: if OIDC not configured, keep existing token form
+
+**`crates/cloudsync-server/src/config.rs`** — Add `oidc_client_id_web: Option<String>`, `oidc_client_secret_web: Option<String>`.
+
+**`crates/cloudsync-server/templates/login.html`** — Conditional rendering: OIDC button vs token form.
+
+### Keycloak web client config
+- Client type: OpenID Connect, confidential
+- Valid redirect URI: `https://cloudsync.example.com/auth/callback`
+- Standard flow: enabled
+
+### Testing
+- Unit test cookie format parsing/verification
+- Manual test with running Keycloak
+
+---
+
+## Phase 5: Client OIDC (Device Authorization Grant)
+
+**Goal:** CLI authenticates via OIDC Device Authorization Grant. Tokens stored and refreshed automatically.
+
+### Changes
+
+**`crates/cloudsync-client/src/auth.rs`** (new):
+- `DeviceAuthFlow`: POST to device authorization endpoint, get `device_code` + `user_code` + `verification_uri`. Poll token endpoint. Open browser with `open` crate.
+- `TokenStore`: persist `access_token`, `refresh_token`, `expires_at` in `.cloudsync/tokens.json` (file permissions `0600`). Transparent refresh on `get_bearer_token()`.
+- `AuthProvider` enum: `StaticToken(String) | Oidc(TokenStore)` — unified `get_bearer_token()` method.
+
+**`crates/cloudsync-client/src/config.rs`** — `token` becomes `Option<String>`. Add `oidc_issuer_url: Option<String>`, `oidc_client_id: Option<String>`.
+
+**`crates/cloudsync-client/src/cli.rs`**:
+- `Init`: `--token` becomes optional. Add `--oidc-issuer-url`, `--oidc-client-id`.
+- Add `Login` subcommand: triggers device auth flow interactively.
+
+**`crates/cloudsync-client/src/client.rs`** — `SyncClient` takes `AuthProvider` instead of raw token. Each request calls `auth_provider.get_bearer_token()`.
+
+**SyncApi trait: unchanged.** Auth is internal to `SyncClient`.
+
+### Keycloak CLI client config
+- Client type: OpenID Connect, public (no secret)
+- Device Authorization Grant: enabled
+- Client ID: `cloudsync-cli`
+
+### New dependencies (client)
+- `open = "5"` — open verification URL in browser
+
+### Testing
+- Mock device auth + token endpoints
+- Test refresh flow, expired refresh → re-login prompt
+
+---
+
+## Phase 6: Keycloak Deployment
+
+**Goal:** Add Keycloak to Docker Compose stack. Provide reproducible setup.
+
+### Changes
+
+**`docker-compose.yml`** — Add `keycloak` service (quay.io/keycloak/keycloak:26.2). Add OIDC env vars to `cloudsync` service.
+
+**`caddy/Caddyfile`** — Add `auth.cloudsync.example.com` vhost → `keycloak:8080`.
+
+**`keycloak/realm-export.json`** (new) — Pre-configured realm with 3 clients (`cloudsync-server`, `cloudsync-web`, `cloudsync-cli`). Import on startup for zero-config.
+
+**`docs/keycloak-setup.md`** (new) — Step-by-step guide: realm creation, client config, user provisioning, token lifetime tuning (access: 5min, refresh: 30 days).
+
+**`docs/server-setup.md`** — Update with Keycloak deployment steps.
+
+---
+
+## Phase 7 (future): Remove Static Token Fallback
+
+Not in initial scope. Once all users migrated: remove `token` from config, make OIDC required. Breaking change — separate release.
+
+---
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Tenant-scoped from the start | Avoids painful migration when multi-tenancy (orgs, shared workspaces) is needed later. `tenant_id` is always a separate generated ID, never equal to `user_id`. |
+| Composite DB key `"{tenant_id}\0{path}"` | redb table names are compile-time constants, so separate tables per tenant is not possible. NUL separator is unambiguous and sortable for prefix scans. |
+| Content-addressable storage stays shared | Dedup across tenants saves space. Metadata layer provides isolation. Hash does not leak ownership. |
+| `sub` claim as `user_id` | Stable, unique OIDC identifier. Email can change. |
+| `tenant_id` resolved from `UserRecord` | Auth layer provides a preliminary `tenant_id`, but the user registry layer overrides it from the DB. This keeps tenant assignment authoritative and centralized. |
+| Static token checked before JWT | Fast path for existing setups. Avoids crypto validation on every request when not using OIDC. |
+| `jsonwebtoken` over `openidconnect` crate | Much lighter. We only need discovery + JWKS + JWT validation. |
+| Device Authorization Grant for CLI | Correct OAuth2 flow for CLI tools — no browser redirect, no local HTTP server. |
+| Keycloak as gatekeeper, not CloudSync | Keycloak controls who can authenticate (self-registration off, admin creates accounts). CloudSync auto-provisions on first valid JWT. `TABLE_USERS` is a mapping + kill switch, not an allowlist. |
+| Minimal PII | Only store `user_id` (opaque UUID `sub`), `tenant_id`, and `is_active`. No email or profile data persisted. Read from JWT claims at request time if needed for display. |
+
+## Verification
+
+After each phase, verify with:
+```bash
+cargo build                        # Compiles
+cargo test                         # All tests pass
+cargo clippy -- --deny warnings    # No warnings
+```
+
+End-to-end after Phase 6:
+1. `docker compose up` — Keycloak + CloudSync start
+2. Import realm, create test user in Keycloak
+3. CLI: `cloudsync init --server-url ... --oidc-issuer-url ... --oidc-client-id cloudsync-cli`
+4. CLI: `cloudsync login` — device flow, approve in browser
+5. CLI: `cloudsync push` / `cloudsync pull` — files scoped to tenant
+6. Web UI: "Sign in with Keycloak" → browse tenant's files
+7. Admin: add second user (own tenant), verify namespace isolation


### PR DESCRIPTION
## Summary
- Introduces `UserContext { tenant_id, user_id }` replacing the unit-struct `AuthGranted`, extracted via Axum's `FromRequestParts`
- All DB operations (files, uploads) now use composite keys `"{tenant_id}\0{path}"` for tenant isolation
- Upload operations (`get`, `add_chunk`, `delete`) verify tenant ownership before proceeding
- Adds `#[serde(default)]` on `tenant_id`/`user_id` fields for backward-compatible deserialization
- Startup migration rewrites old plain-path keys to composite format, backfilling tenant/user IDs
- Schema versioning via `TABLE_META` ensures migration runs only once
- Static token auth maps to configurable `default_tenant_id`/`default_user_id` (CLI flags + env vars)
- Content-addressable blob storage remains shared across tenants (dedup by design)

Closes #26

## Test plan
- [x] Existing tests pass with tenant-scoped DB operations
- [x] Cross-tenant isolation test verifies tenant A cannot see tenant B's files
- [x] Migration test verifies old keys are rewritten and values backfilled
- [x] Schema version tracking prevents duplicate migration runs
- [x] `cargo clippy -- --deny warnings` passes clean