### PR TITLE
Add log-based observability stack (Grafana + Loki + Promtail)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,17 +17,29 @@ jobs:
         env:
           DEPLOY_SSH_KEY: ${{ secrets.CLOUDSYNC_HETZNER_PRIVATE_KEY }}
           CLOUDSYNC_TOKEN: ${{ secrets.CLOUDSYNC_TOKEN }}
+          CLOUDSYNC_GRAFANA_ADMIN_PASSWORD: ${{ secrets.CLOUDSYNC_GRAFANA_ADMIN_PASSWORD }}
         run: |
           mkdir -p ~/.ssh
           echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           scp -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key docker-compose.yml root@46.224.102.7:~/docker-compose.yml
           scp -r -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key caddy root@46.224.102.7:~/caddy
+          scp -r -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key observability root@46.224.102.7:~/observability
           ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key root@46.224.102.7 << EOF
+            # Loki runs as UID 10001, Grafana as UID 472 — ensure their data
+            # dirs exist on the volume with correct ownership before first start.
+            mkdir -p /mnt/volume-cloudsync/loki /mnt/volume-cloudsync/grafana
+            chown -R 10001:10001 /mnt/volume-cloudsync/loki
+            chown -R 472:472 /mnt/volume-cloudsync/grafana
+
             CLOUDSYNC_DOCKER_TAG=${{ inputs.version }} \
             CLOUDSYNC_MOUNT_DIR=/mnt/volume-cloudsync/cloudsync \
             CLOUDSYNC_TOKEN=$CLOUDSYNC_TOKEN \
             CLOUDSYNC_CADDY_MOUNT_DIR=/mnt/volume-cloudsync/caddy \
             CLOUDSYNC_CADDYFILE_DIR=./caddy \
+            CLOUDSYNC_OBSERVABILITY_DIR=./observability \
+            CLOUDSYNC_LOKI_MOUNT_DIR=/mnt/volume-cloudsync/loki \
+            CLOUDSYNC_GRAFANA_MOUNT_DIR=/mnt/volume-cloudsync/grafana \
+            CLOUDSYNC_GRAFANA_ADMIN_PASSWORD=$CLOUDSYNC_GRAFANA_ADMIN_PASSWORD \
             docker compose -f ~/docker-compose.yml up -d
           EOF

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,3 +1,7 @@
-cloudsync.devchris.dev
+cloudsync.devchris.dev {
+	reverse_proxy cloudsync:3050
+}
 
-reverse_proxy cloudsync:3050
+monitoring.devchris.dev {
+	reverse_proxy grafana:3000
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,42 @@ services:
       - ${CLOUDSYNC_CADDY_MOUNT_DIR}/config:/config
       - ${CLOUDSYNC_CADDYFILE_DIR}:/etc/caddy
     restart: unless-stopped
+
+  # --- Observability stack ---
+  # Logs from every container on this host flow through Promtail → Loki,
+  # browseable via Grafana at monitoring.devchris.dev.
+
+  loki:
+    image: grafana/loki:3.6.11@sha256:44148ad243c07957113baea950ee5ba9b0c8eff8d7e38ff3cc1c0af705790945
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ${CLOUDSYNC_OBSERVABILITY_DIR}/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - ${CLOUDSYNC_LOKI_MOUNT_DIR}:/loki
+    restart: unless-stopped
+
+  promtail:
+    image: grafana/promtail:3.6.11@sha256:a761cb834cfaeee29745440d4884d6748f0a08d8f68928db1d707018c1dcfbe9
+    command: -config.file=/etc/promtail/promtail-config.yml
+    volumes:
+      - ${CLOUDSYNC_OBSERVABILITY_DIR}/promtail/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    depends_on:
+      - loki
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:13.0.2@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
+    volumes:
+      - ${CLOUDSYNC_GRAFANA_MOUNT_DIR}:/var/lib/grafana
+      - ${CLOUDSYNC_OBSERVABILITY_DIR}/grafana/provisioning:/etc/grafana/provisioning:ro
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${CLOUDSYNC_GRAFANA_ADMIN_PASSWORD}
+      - GF_SERVER_ROOT_URL=https://monitoring.devchris.dev
+      # Behind Caddy, so trust the X-Forwarded-* headers it sets.
+      - GF_SERVER_ENFORCE_DOMAIN=false
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_ANALYTICS_CHECK_FOR_UPDATES=false
+    depends_on:
+      - loki
+    restart: unless-stopped

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -64,6 +64,12 @@ rm /tmp/deploy_key /tmp/deploy_key.pub
 
 Set the `CLOUDSYNC_TOKEN` on the server (or store as a GitHub secret and pass during deploy).
 
+For the observability stack (see §7), also set `CLOUDSYNC_GRAFANA_ADMIN_PASSWORD` as a GitHub secret:
+
+```sh
+gh secret set CLOUDSYNC_GRAFANA_ADMIN_PASSWORD
+```
+
 ## 6. First Deploy
 
 The release workflow (`.github/workflows/release.yml`) handles:
@@ -72,3 +78,21 @@ The release workflow (`.github/workflows/release.yml`) handles:
 - SSHing into the server
 - Copying `docker-compose.yml` to the server
 - Running `docker compose up -d` with env vars for image tag, mount dir, and token
+
+## 7. Observability (Grafana + Loki + Promtail)
+
+Logs from every container on the host flow through Promtail into Loki and are
+browseable in Grafana at `https://monitoring.devchris.dev`.
+
+One-time DNS setup: add an A record for `monitoring.devchris.dev`
+pointing to the VPS IP. Caddy will provision the TLS cert automatically on
+first request.
+
+The deploy workflow creates `/mnt/volume-cloudsync/loki` and
+`/mnt/volume-cloudsync/grafana` with the right ownership (UID 10001 and 472
+respectively) — no manual setup needed beyond the DNS record and the
+`CLOUDSYNC_GRAFANA_ADMIN_PASSWORD` secret.
+
+First login: username `admin`, password from the secret. Loki is
+auto-provisioned as the default datasource; use the **Explore** tab and query
+`{container="cloudsync"}` to tail server logs.

--- a/observability/grafana/provisioning/datasources/loki.yml
+++ b/observability/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,14 @@
+# Auto-provisions Loki as the default Grafana datasource on first start.
+# https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources
+
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    editable: false
+    jsonData:
+      maxLines: 1000

--- a/observability/loki/loki-config.yml
+++ b/observability/loki/loki-config.yml
@@ -1,0 +1,50 @@
+# Loki single-binary config for CloudSync.
+# Filesystem-backed storage on the Hetzner volume; 7-day retention.
+# https://grafana.com/docs/loki/latest/configure/
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+# 7-day retention enforced by the compactor.
+limits_config:
+  retention_period: 168h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  allow_structured_metadata: true
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: filesystem
+
+# Single-tenant install — no analytics phone-home.
+analytics:
+  reporting_enabled: false

--- a/observability/promtail/promtail-config.yml
+++ b/observability/promtail/promtail-config.yml
@@ -1,0 +1,34 @@
+# Promtail config for CloudSync.
+# Auto-discovers all running containers via the Docker socket and ships
+# their stdout/stderr to Loki. No app-side instrumentation needed.
+# https://grafana.com/docs/loki/latest/send-data/promtail/configuration/
+
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+  log_level: warn
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      # Strip the leading slash off Docker container names.
+      - source_labels: ["__meta_docker_container_name"]
+        regex: "/(.*)"
+        target_label: container
+      # Carry the compose service name through as `service` for nicer queries
+      # (e.g. {service="cloudsync"} works regardless of container suffix).
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: service
+      # Static label so we can filter all VPS logs at once if we ever
+      # add a second host.
+      - target_label: host
+        replacement: cloudsync-vps


### PR DESCRIPTION
Closes #29.

## What

Adds three containers to `docker-compose.yml`: **Loki** (log store, 7-day retention, on the Hetzner volume), **Promtail** (scrapes Docker socket, no app changes needed), and **Grafana** (UI, served at `monitoring.cloudsync.devchris.dev` via the existing Caddy reverse proxy).

Configs live under `observability/` and ship via the deploy workflow alongside `caddy/`.

## Verified locally

- All five containers come up healthy after fixing one Caddyfile bug (multi-site needs curly braces — the original single-site form doesn't extend).
- Loki labels populated correctly: `container`, `service`, `host`. `{service="cloudsync"}` returns the actual `server listening on 0.0.0.0:3050` log line.
- Grafana healthy, Loki auto-provisioned as the default datasource (`readOnly:true` confirms it came from provisioning).
- Caddy parses both vhosts. Local TLS testing isn't possible (DNS doesn't resolve to localhost), but the routing decision is independent of the cert.

## Before merging

Two manual prerequisites for production:

1. **DNS:** Add A record `monitoring.cloudsync.devchris.dev` → `46.224.102.7`.
2. **Secret:** `gh secret set CLOUDSYNC_GRAFANA_ADMIN_PASSWORD`.

Both are documented in `docs/server-setup.md` §7.

## Observation worth flagging

Once this is up, you'll quickly notice CloudSync only logs server startup + a few file-store/metadata events. There are no per-request access logs from `cloudsync-server`, so request-level debugging will go through Caddy's access log (`{service="reverse-proxy"}`) for now. Adding `tower-http::trace::TraceLayer` to Axum would give us per-request log lines with method/path/status/latency — could be a small follow-up.

## Image versions (digest-pinned)

- `grafana/loki:3.6.11`
- `grafana/promtail:3.6.11` (Loki 3.7.x doesn't have a matching Promtail release yet, so pinning the pair at 3.6.11)
- `grafana/grafana:13.0.2`

## Out of scope (deferred)

- Traces (would need `tracing-opentelemetry` in `cloudsync-server` + Tempo)
- Metrics / alerts / provisioned dashboards