### PR TITLE
Validate OIDC JWTs and deploy Keycloak as the IdP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,13 @@ Environment variables / CLI flags:
 - `CLOUDSYNC_STORAGE_DIR` (default: cloudsync/data/files)
 - `CLOUDSYNC_DBNAME` (default: data.redb)
 
+Optional OIDC (enables JWT auth alongside the static token):
+- `CLOUDSYNC_OIDC_ISSUER` — public issuer URL; matched against the JWT `iss` claim
+- `CLOUDSYNC_OIDC_DISCOVERY_URL` — URL used to fetch `.well-known/openid-configuration` and JWKS; defaults to `CLOUDSYNC_OIDC_ISSUER`. Useful when the IdP is reachable on a different internal hostname (e.g. inside Docker)
+- `CLOUDSYNC_OIDC_AUDIENCE` (default: `cloudsync`) — expected `aud` claim
+
+The OIDC variables are **integrity-critical**: anyone who controls them controls who can authenticate. In particular, `CLOUDSYNC_OIDC_DISCOVERY_URL` points the server at the JWKS it will trust to verify signatures — pointing it at an attacker-controlled host is equivalent to handing out signing keys. Set these via the deployment's secret/config store, not from a checked-in `.env`. Use `https://` for any discovery URL crossing an untrusted network; never disable TLS verification on it.
+
 ## API Endpoints
 
 All require `Authorization: Bearer <token>` except health:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "cloudsync-common",
  "hex",
  "hmac",
+ "jsonwebtoken",
  "mime_guess",
  "nanoid",
  "redb",
@@ -468,6 +469,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1035,6 +1045,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1194,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1263,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1298,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1726,6 +1792,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,6 +1920,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,10 +218,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-toml"
@@ -390,6 +402,7 @@ dependencies = [
  "anyhow",
  "askama",
  "axum",
+ "base64",
  "chrono",
  "clap",
  "cloudsync-common",
@@ -398,8 +411,10 @@ dependencies = [
  "jsonwebtoken",
  "mime_guess",
  "nanoid",
+ "p256",
  "redb",
  "reqwest",
+ "rsa",
  "rust-embed",
  "serde",
  "serde_json",
@@ -432,6 +447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +483,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +502,17 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -487,6 +531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -500,6 +545,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -538,6 +617,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -656,6 +745,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -696,6 +786,17 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1064,6 +1165,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1076,6 +1180,12 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1204,6 +1314,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,12 +1345,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1238,6 +1376,18 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1273,6 +1423,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1442,27 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1322,6 +1502,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1546,6 +1735,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1756,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1673,6 +1892,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "semver"
@@ -1792,6 +2025,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +2073,16 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -5,3 +5,7 @@ cloudsync.devchris.dev {
 monitoring.devchris.dev {
 	reverse_proxy grafana:3000
 }
+
+auth.devchris.dev {
+    reverse_proxy keycloak:8080
+}

--- a/crates/cloudsync-client/tests/integration_test.rs
+++ b/crates/cloudsync-client/tests/integration_test.rs
@@ -37,6 +37,7 @@ async fn test_push_and_pull() {
         dbname: dbname.to_string(),
         default_tenant_id: "tenant".to_string(),
         default_user_id: "user".to_string(),
+        oidc_issuer: None,
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -117,6 +118,7 @@ async fn test_pull_conflict() {
         dbname: dbname.to_string(),
         default_tenant_id: "tenant".to_string(),
         default_user_id: "user".to_string(),
+        oidc_issuer: None,
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/cloudsync-client/tests/integration_test.rs
+++ b/crates/cloudsync-client/tests/integration_test.rs
@@ -37,7 +37,7 @@ async fn test_push_and_pull() {
         dbname: dbname.to_string(),
         default_tenant_id: "tenant".to_string(),
         default_user_id: "user".to_string(),
-        oidc_issuer: None,
+        oidc_config: None,
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -118,7 +118,7 @@ async fn test_pull_conflict() {
         dbname: dbname.to_string(),
         default_tenant_id: "tenant".to_string(),
         default_user_id: "user".to_string(),
-        oidc_issuer: None,
+        oidc_config: None,
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/cloudsync-client/tests/integration_test.rs
+++ b/crates/cloudsync-client/tests/integration_test.rs
@@ -31,6 +31,8 @@ async fn test_push_and_pull() {
         .unwrap()
         .to_string();
     let server = cloudsync_server::app::bootstrap_app(ServerConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
         storage_dir: storage_dir_str,
         staging_dir: staging_dir_str,
         token: token.to_string(),
@@ -112,6 +114,8 @@ async fn test_pull_conflict() {
         .unwrap()
         .to_string();
     let server = cloudsync_server::app::bootstrap_app(ServerConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
         storage_dir: storage_dir_str,
         staging_dir: staging_dir_str,
         token: token.to_string(),

--- a/crates/cloudsync-server/Cargo.toml
+++ b/crates/cloudsync-server/Cargo.toml
@@ -18,7 +18,9 @@ tracing-subscriber = { workspace = true }
 tower-http = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
+reqwest = { workspace = true }
 nanoid = "0.4"
+jsonwebtoken = "9"
 # Web UI
 askama = "0.15"
 rust-embed = "8"

--- a/crates/cloudsync-server/Cargo.toml
+++ b/crates/cloudsync-server/Cargo.toml
@@ -31,4 +31,7 @@ mime_guess = "2"
 
 [dev-dependencies]
 tempfile = "3"
+base64 = { version = "0.22" }
+rsa = "0.9"
+p256 = "0.13"
 reqwest = { workspace = true }

--- a/crates/cloudsync-server/src/app.rs
+++ b/crates/cloudsync-server/src/app.rs
@@ -398,7 +398,7 @@ pub fn bootstrap_app(config: ServerConfig) -> anyhow::Result<Router> {
         default_user_id: config.default_user_id,
         oidc: config
             .oidc_issuer
-            .map(|iss| Arc::new(OidcValidator { issuer: iss })),
+            .map(|iss| Arc::new(OidcValidator::new(iss, "".to_string()))),
     };
     let app = create_app(state);
     Ok(app)

--- a/crates/cloudsync-server/src/app.rs
+++ b/crates/cloudsync-server/src/app.rs
@@ -5,7 +5,7 @@ use axum::{
     body::{self},
     debug_handler,
     extract::{self, DefaultBodyLimit, FromRequestParts, Multipart, Path, Request, State},
-    http::StatusCode,
+    http::{HeaderValue, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
     routing::{delete, get, post, put},
@@ -22,7 +22,12 @@ use cloudsync_common::{
 use redb::Database;
 
 use crate::{
-    auth::UserContext, config::ServerConfig, db::TenantDb, db_upload::TenantUploadDb, migrations,
+    auth::UserContext,
+    config::ServerConfig,
+    db::TenantDb,
+    db_upload::TenantUploadDb,
+    migrations,
+    oidc::{Claims, OidcValidator},
 };
 
 use super::db;
@@ -36,6 +41,7 @@ pub struct AppState {
     pub token: String,
     pub default_tenant_id: String,
     pub default_user_id: String,
+    pub oidc: Option<Arc<OidcValidator>>,
 }
 
 struct AppError(anyhow::Error, StatusCode);
@@ -261,16 +267,43 @@ async fn bearer_auth_layer(
     mut request: Request,
     next: Next,
 ) -> Response {
-    if let Some(auth_header) = request.headers().get("Authorization")
-        && auth_header.to_str().unwrap() == format!("Bearer {}", state.token)
-    {
-        tracing::trace!("bearer token valid");
-        request.extensions_mut().insert(UserContext {
-            tenant_id: state.default_tenant_id,
-            user_id: state.default_user_id,
-        });
+    if let Some(auth_header) = request.headers().get("Authorization") {
+        let claims = if let Some(oidc) = state.oidc {
+            get_claims(auth_header, &oidc).await
+        } else {
+            tracing::debug!("oidc not configured (OIDC)");
+            Ok(None)
+        };
+        if let Err(err) = &claims {
+            tracing::error!("error validating token: {} (OIDC)", err);
+        }
+        if let Ok(Some(claims)) = claims {
+            // tenant_id = sub for now; extend with custom claims for shared tenants later
+            request.extensions_mut().insert(UserContext {
+                tenant_id: claims.sub.clone(),
+                user_id: claims.sub,
+            });
+        } else if auth_header.to_str().unwrap_or("") == format!("Bearer {}", state.token) {
+            tracing::trace!("bearer token valid (Servertoken)");
+            request.extensions_mut().insert(UserContext {
+                tenant_id: state.default_tenant_id,
+                user_id: state.default_user_id,
+            });
+        }
     }
     next.run(request).await
+}
+
+async fn get_claims(
+    auth_header: &HeaderValue,
+    oidc: &OidcValidator,
+) -> anyhow::Result<Option<Claims>> {
+    let jwt = auth_header.to_str()?.strip_prefix("Bearer ");
+    if let Some(jwt) = jwt {
+        let res = oidc.validate(jwt.to_string()).await?;
+        return Ok(Some(res));
+    }
+    Ok(None)
 }
 
 async fn cookie_auth_layer(
@@ -297,7 +330,7 @@ async fn require_auth_layer(request: Request, next: Next) -> Result<Response, St
         Ok(next.run(request).await)
     } else {
         tracing::warn!("access denied: no valid authorization");
-        Err(StatusCode::FORBIDDEN)
+        Err(StatusCode::UNAUTHORIZED)
     }
 }
 
@@ -363,6 +396,9 @@ pub fn bootstrap_app(config: ServerConfig) -> anyhow::Result<Router> {
         token: config.token,
         default_tenant_id: config.default_tenant_id,
         default_user_id: config.default_user_id,
+        oidc: config
+            .oidc_issuer
+            .map(|iss| Arc::new(OidcValidator { issuer: iss })),
     };
     let app = create_app(state);
     Ok(app)

--- a/crates/cloudsync-server/src/app.rs
+++ b/crates/cloudsync-server/src/app.rs
@@ -396,9 +396,13 @@ pub fn bootstrap_app(config: ServerConfig) -> anyhow::Result<Router> {
         token: config.token,
         default_tenant_id: config.default_tenant_id,
         default_user_id: config.default_user_id,
-        oidc: config
-            .oidc_issuer
-            .map(|iss| Arc::new(OidcValidator::new(iss, "".to_string()))),
+        oidc: config.oidc_config.map(|oidc| {
+            Arc::new(OidcValidator::new(
+                oidc.issuer,
+                oidc.discovery_url,
+                oidc.audience,
+            ))
+        }),
     };
     let app = create_app(state);
     Ok(app)

--- a/crates/cloudsync-server/src/cli.rs
+++ b/crates/cloudsync-server/src/cli.rs
@@ -34,4 +34,7 @@ pub struct Args {
         default_value = "default-user"
     )]
     pub default_user_id: String,
+
+    #[arg(long, env = "CLOUDSYNC_OIDC_ISSUER")]
+    pub oidc_issuer: Option<String>,
 }

--- a/crates/cloudsync-server/src/cli.rs
+++ b/crates/cloudsync-server/src/cli.rs
@@ -35,6 +35,25 @@ pub struct Args {
     )]
     pub default_user_id: String,
 
-    #[arg(long, env = "CLOUDSYNC_OIDC_ISSUER")]
+    #[arg(
+        long,
+        env = "CLOUDSYNC_OIDC_ISSUER",
+        help = "Expected issuer URL for JWT validation"
+    )]
     pub oidc_issuer: Option<String>,
+
+    #[arg(
+        long,
+        env = "CLOUDSYNC_OIDC_DISCOVERY_URL",
+        help = "Internal URL to fetch OIDC discovery document (defaults to issuer URL if not set)"
+    )]
+    pub oidc_discovery_url: Option<String>,
+
+    #[arg(
+        long,
+        env = "CLOUDSYNC_OIDC_AUDIENCE",
+        help = "OIDC client ID used to validate the audience claim",
+        default_value = "cloudsync"
+    )]
+    pub oidc_audience: Option<String>,
 }

--- a/crates/cloudsync-server/src/config.rs
+++ b/crates/cloudsync-server/src/config.rs
@@ -5,4 +5,5 @@ pub struct ServerConfig {
     pub dbname: String,
     pub default_tenant_id: String,
     pub default_user_id: String,
+    pub oidc_issuer: Option<String>,
 }

--- a/crates/cloudsync-server/src/config.rs
+++ b/crates/cloudsync-server/src/config.rs
@@ -1,9 +1,17 @@
+pub struct OidcConfig {
+    pub issuer: String,
+    pub discovery_url: String,
+    pub audience: String,
+}
+
 pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
     pub storage_dir: String,
     pub staging_dir: String,
     pub token: String,
     pub dbname: String,
     pub default_tenant_id: String,
     pub default_user_id: String,
-    pub oidc_issuer: Option<String>,
+    pub oidc_config: Option<OidcConfig>,
 }

--- a/crates/cloudsync-server/src/lib.rs
+++ b/crates/cloudsync-server/src/lib.rs
@@ -3,6 +3,7 @@ mod auth;
 pub mod config;
 mod db;
 mod db_upload;
+mod oidc;
 mod storage;
 mod ui;
 

--- a/crates/cloudsync-server/src/main.rs
+++ b/crates/cloudsync-server/src/main.rs
@@ -18,6 +18,7 @@ async fn main() -> anyhow::Result<()> {
         dbname: args.dbname,
         default_tenant_id: args.default_tenant_id,
         default_user_id: args.default_user_id,
+        oidc_issuer: args.oidc_issuer,
     };
 
     // Start server

--- a/crates/cloudsync-server/src/main.rs
+++ b/crates/cloudsync-server/src/main.rs
@@ -11,22 +11,119 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
-    let config = config::ServerConfig {
+    let config = create_config(args);
+    log_auth_posture(&config);
+
+    // Start server
+    let host = config.host.clone();
+    let port = config.port;
+    let app = app::bootstrap_app(config).unwrap();
+    let listener = tokio::net::TcpListener::bind(format!("{}:{}", host, port))
+        .await
+        .unwrap();
+    tracing::info!("server listening on {}:{}", host, port);
+    axum::serve(listener, app).await.unwrap();
+    Ok(())
+}
+
+/// Log which auth mechanisms are active so the deployed posture is visible
+/// in logs. The OIDC issuer/audience are integrity-critical config; surfacing
+/// them on startup makes a misconfigured deploy easy to spot.
+fn log_auth_posture(config: &config::ServerConfig) {
+    match &config.oidc_config {
+        Some(oidc) => tracing::info!(
+            issuer = %oidc.issuer,
+            discovery_url = %oidc.discovery_url,
+            audience = %oidc.audience,
+            "auth: OIDC enabled (static token also accepted)"
+        ),
+        None => tracing::warn!("auth: OIDC disabled, only static token accepted"),
+    }
+}
+
+fn create_config(args: cli::Args) -> config::ServerConfig {
+    config::ServerConfig {
+        host: args.host,
+        port: args.port,
         storage_dir: args.storage_dir,
         staging_dir: args.staging_dir,
         token: args.token,
         dbname: args.dbname,
         default_tenant_id: args.default_tenant_id,
         default_user_id: args.default_user_id,
-        oidc_issuer: args.oidc_issuer,
-    };
+        oidc_config: match (
+            args.oidc_issuer,
+            args.oidc_discovery_url,
+            args.oidc_audience,
+        ) {
+            (Some(issuer), discovery_url, Some(audience)) => Some(config::OidcConfig {
+                discovery_url: discovery_url.unwrap_or_else(|| issuer.clone()),
+                issuer,
+                audience,
+            }),
+            _ => None,
+        },
+    }
+}
 
-    // Start server
-    let app = app::bootstrap_app(config).unwrap();
-    let listener = tokio::net::TcpListener::bind(format!("{}:{}", args.host, args.port))
-        .await
-        .unwrap();
-    tracing::info!("server listening on {}:{}", args.host, args.port);
-    axum::serve(listener, app).await.unwrap();
-    Ok(())
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_config_defaults_to_issuer() {
+        let args = cli::Args {
+            host: "localhost".to_string(),
+            port: 0,
+            token: "test_token".to_string(),
+            storage_dir: "test_storage".to_string(),
+            staging_dir: "test_staging".to_string(),
+            dbname: "test_db".to_string(),
+            default_tenant_id: "test_tenant".to_string(),
+            default_user_id: "test_user".to_string(),
+            oidc_issuer: Some("https://example.com/issuer".to_string()),
+            oidc_discovery_url: None,
+            oidc_audience: Some("cloudsync".to_string()),
+        };
+
+        let config = create_config(args);
+
+        assert!(config.oidc_config.is_some());
+        let oidc_config = config.oidc_config.unwrap();
+        assert_eq!(oidc_config.issuer, "https://example.com/issuer");
+        assert_eq!(oidc_config.discovery_url, "https://example.com/issuer");
+        assert_eq!(oidc_config.audience, "cloudsync");
+    }
+
+    #[test]
+    fn test_create_config_keeps_distinct_discovery_url() {
+        // Public issuer and internal discovery URL differ — the common
+        // Docker case where the IdP is reachable on a different hostname
+        // from inside the network.
+        let args = cli::Args {
+            host: "localhost".to_string(),
+            port: 0,
+            token: "test_token".to_string(),
+            storage_dir: "test_storage".to_string(),
+            staging_dir: "test_staging".to_string(),
+            dbname: "test_db".to_string(),
+            default_tenant_id: "test_tenant".to_string(),
+            default_user_id: "test_user".to_string(),
+            oidc_issuer: Some("https://auth.example.com/realms/cloudsync".to_string()),
+            oidc_discovery_url: Some("http://keycloak:8080/realms/cloudsync".to_string()),
+            oidc_audience: Some("cloudsync".to_string()),
+        };
+
+        let config = create_config(args);
+
+        let oidc_config = config.oidc_config.expect("oidc config should be set");
+        assert_eq!(
+            oidc_config.issuer,
+            "https://auth.example.com/realms/cloudsync"
+        );
+        assert_eq!(
+            oidc_config.discovery_url,
+            "http://keycloak:8080/realms/cloudsync"
+        );
+    }
 }

--- a/crates/cloudsync-server/src/oidc.rs
+++ b/crates/cloudsync-server/src/oidc.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone)]
+pub struct OidcValidator {
+    pub issuer: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    pub sub: String,
+    pub aud: String,
+    pub email: String,
+}
+
+impl OidcValidator {
+    pub async fn validate(&self, jwt: String) -> anyhow::Result<Claims> {
+        // Fetch well known
+
+        // Fetch JWKS
+        let jwks = fetch_jwks(&self.issuer).await?;
+
+        // JWT decode
+        let header = jsonwebtoken::decode_header(jwt.as_str())?;
+
+        // Check whick key
+        let kid = header
+            .kid
+            .ok_or_else(|| anyhow::anyhow!("missing kid header field"))?;
+        let jwk = jwks
+            .keys
+            .iter()
+            .find(|k| k.kid == kid)
+            .ok_or_else(|| anyhow::anyhow!("no matching key for kid: {kid}"))?;
+        let key = jsonwebtoken::DecodingKey::from_rsa_components(&jwk.n, &jwk.e)?;
+
+        // Verify
+        let claims = jsonwebtoken::decode::<Claims>(
+            &jwt,
+            &key,
+            &jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256),
+        )?;
+
+        Ok(claims.claims)
+    }
+}
+
+#[derive(Deserialize)]
+struct OidcDiscovery {
+    jwks_uri: String,
+    issuer: String,
+}
+
+#[derive(Deserialize)]
+struct Jwks {
+    keys: Vec<Jwk>,
+}
+
+#[derive(Deserialize)]
+struct Jwk {
+    kid: String,
+    n: String,
+    e: String,
+}
+
+async fn fetch_jwks(issuer: &str) -> anyhow::Result<Jwks> {
+    // Get jwks_uri
+    let well_known = ".well-known/openid-configuration";
+    let well_known = format!("{issuer}/{well_known}");
+    let client: reqwest::Client = reqwest::Client::new();
+    let response = client.get(well_known).send().await?;
+    let bytes = response.bytes().await?;
+    let oidc = serde_json::from_slice::<OidcDiscovery>(&bytes)?;
+
+    if oidc.issuer != issuer {
+        anyhow::bail!("issuer does not match");
+    }
+
+    // Fetch jwks
+    let jwks_resp = client.get(oidc.jwks_uri).send().await?;
+    let bytes = jwks_resp.bytes().await?;
+    let jwks = serde_json::from_slice::<Jwks>(&bytes)?;
+
+    Ok(jwks)
+}

--- a/crates/cloudsync-server/src/oidc.rs
+++ b/crates/cloudsync-server/src/oidc.rs
@@ -36,11 +36,8 @@ struct Jwks {
 #[derive(Deserialize, Clone)]
 #[serde(tag = "kty")]
 enum Jwk {
-    RSA {
-        kid: String,
-        n: String,
-        e: String,
-    },
+    #[serde(rename = "RSA")]
+    Rsa { kid: String, n: String, e: String },
     EC {
         kid: String,
         x: String,
@@ -122,10 +119,10 @@ impl OidcValidator {
     async fn fetch_well_known(&self) -> anyhow::Result<OidcDiscovery> {
         {
             let cache = self.well_known_cache.read().await;
-            if let Some((oidc, fetched_at)) = &*cache {
-                if fetched_at.elapsed() < Duration::from_secs(3600) {
-                    return Ok(oidc.clone());
-                }
+            if let Some((oidc, fetched_at)) = &*cache
+                && fetched_at.elapsed() < Duration::from_secs(3600)
+            {
+                return Ok(oidc.clone());
             }
         }
         let well_known = ".well-known/openid-configuration";
@@ -146,10 +143,10 @@ impl OidcValidator {
     async fn fetch_jwks(&self, oidc: &OidcDiscovery) -> anyhow::Result<Jwks> {
         {
             let cache = self.jwks_cache.read().await;
-            if let Some((jwks, fetched_at)) = cache.as_ref() {
-                if fetched_at.elapsed() < Duration::from_secs(300) {
-                    return Ok(jwks.clone());
-                }
+            if let Some((jwks, fetched_at)) = cache.as_ref()
+                && fetched_at.elapsed() < Duration::from_secs(300)
+            {
+                return Ok(jwks.clone());
             }
         }
 
@@ -171,13 +168,13 @@ impl OidcValidator {
             .keys
             .iter()
             .find(|k| match k {
-                Jwk::RSA { kid: mykid, .. } => *mykid == kid,
+                Jwk::Rsa { kid: mykid, .. } => *mykid == kid,
                 Jwk::EC { kid: mykid, .. } => *mykid == kid,
             })
             .ok_or_else(|| ValidationError::UnknownKid(kid))?;
 
         let (alg, key) = match jwk {
-            Jwk::RSA { n, e, .. } => (
+            Jwk::Rsa { n, e, .. } => (
                 Algorithm::RS256,
                 jsonwebtoken::DecodingKey::from_rsa_components(n, e)?,
             ),
@@ -200,7 +197,7 @@ impl OidcValidator {
         validation.set_issuer(&[&self.issuer]);
         validation.set_audience(&[&self.audience]);
         validation.set_required_spec_claims(&["exp", "iss", "aud"]);
-        let claims = jsonwebtoken::decode::<Claims>(&jwt, &key, &validation)?;
+        let claims = jsonwebtoken::decode::<Claims>(jwt, &key, &validation)?;
         Ok(claims.claims)
     }
 }
@@ -436,7 +433,7 @@ Nc3GLyMxuf/cuSIU05L70Os=
         (
             private_key.into(),
             Jwks {
-                keys: vec![Jwk::RSA {
+                keys: vec![Jwk::Rsa {
                     kid: "test-kid".into(),
                     n: n.into(),
                     e: e.into(),

--- a/crates/cloudsync-server/src/oidc.rs
+++ b/crates/cloudsync-server/src/oidc.rs
@@ -1,84 +1,462 @@
-use serde::{Deserialize, Serialize};
+use std::{sync::Arc, time::Instant};
 
-#[derive(Clone)]
-pub struct OidcValidator {
-    pub issuer: String,
-}
+use jsonwebtoken::Algorithm;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tokio::sync::RwLock;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
     pub sub: String,
+    pub iss: String,
     pub aud: String,
     pub email: String,
+    pub exp: usize,
 }
 
-impl OidcValidator {
-    pub async fn validate(&self, jwt: String) -> anyhow::Result<Claims> {
-        // Fetch well known
-
-        // Fetch JWKS
-        let jwks = fetch_jwks(&self.issuer).await?;
-
-        // JWT decode
-        let header = jsonwebtoken::decode_header(jwt.as_str())?;
-
-        // Check whick key
-        let kid = header
-            .kid
-            .ok_or_else(|| anyhow::anyhow!("missing kid header field"))?;
-        let jwk = jwks
-            .keys
-            .iter()
-            .find(|k| k.kid == kid)
-            .ok_or_else(|| anyhow::anyhow!("no matching key for kid: {kid}"))?;
-        let key = jsonwebtoken::DecodingKey::from_rsa_components(&jwk.n, &jwk.e)?;
-
-        // Verify
-        let claims = jsonwebtoken::decode::<Claims>(
-            &jwt,
-            &key,
-            &jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256),
-        )?;
-
-        Ok(claims.claims)
-    }
-}
-
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 struct OidcDiscovery {
     jwks_uri: String,
     issuer: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 struct Jwks {
     keys: Vec<Jwk>,
 }
 
-#[derive(Deserialize)]
-struct Jwk {
-    kid: String,
-    n: String,
-    e: String,
+#[derive(Deserialize, Clone)]
+#[serde(tag = "kty")]
+enum Jwk {
+    RSA {
+        kid: String,
+        n: String,
+        e: String,
+    },
+    EC {
+        kid: String,
+        x: String,
+        y: String,
+        crv: String,
+    },
 }
 
-async fn fetch_jwks(issuer: &str) -> anyhow::Result<Jwks> {
-    // Get jwks_uri
-    let well_known = ".well-known/openid-configuration";
-    let well_known = format!("{issuer}/{well_known}");
-    let client: reqwest::Client = reqwest::Client::new();
-    let response = client.get(well_known).send().await?;
-    let bytes = response.bytes().await?;
-    let oidc = serde_json::from_slice::<OidcDiscovery>(&bytes)?;
+#[derive(Debug)]
+enum ValidationError {
+    MissingKid,
+    UnknownKid(String),
+    Other(anyhow::Error),
+}
 
-    if oidc.issuer != issuer {
-        anyhow::bail!("issuer does not match");
+impl From<anyhow::Error> for ValidationError {
+    fn from(err: anyhow::Error) -> Self {
+        ValidationError::Other(err)
+    }
+}
+
+impl From<jsonwebtoken::errors::Error> for ValidationError {
+    fn from(err: jsonwebtoken::errors::Error) -> Self {
+        ValidationError::Other(err.into())
+    }
+}
+
+#[derive(Clone)]
+pub struct OidcValidator {
+    pub issuer: String,
+    pub audience: String,
+    pub client: Client,
+    well_known_cache: Arc<RwLock<Option<(OidcDiscovery, std::time::Instant)>>>,
+    jwks_cache: Arc<RwLock<Option<(Jwks, std::time::Instant)>>>,
+}
+
+impl OidcValidator {
+    pub fn new(issuer: String, audience: String) -> Self {
+        OidcValidator {
+            issuer,
+            audience,
+            client: reqwest::Client::new(),
+            well_known_cache: Arc::new(RwLock::new(None)),
+            jwks_cache: Arc::new(RwLock::new(None)),
+        }
     }
 
-    // Fetch jwks
-    let jwks_resp = client.get(oidc.jwks_uri).send().await?;
-    let bytes = jwks_resp.bytes().await?;
-    let jwks = serde_json::from_slice::<Jwks>(&bytes)?;
+    pub async fn validate(&self, jwt: String) -> anyhow::Result<Claims> {
+        // Fetch well known
+        let oidc = self.fetch_well_known().await?;
+        if oidc.issuer != self.issuer {
+            anyhow::bail!("issuer does not match");
+        }
 
-    Ok(jwks)
+        // Fetch JWKS
+        let jwks = self.fetch_jwks(&oidc).await?;
+
+        // Validate JWT
+        let claims = self.validate_jwt(jwt.as_str(), &jwks);
+
+        match claims {
+            Ok(claims) => Ok(claims),
+            Err(ValidationError::UnknownKid(kid)) => {
+                tracing::warn!("unknown kid in JWT: {kid}, refreshing JWKS and retrying");
+                // Key might have rotated, reftech JWKS and retry once
+                self.invalidate_cache().await;
+                let jwks = self.fetch_jwks(&oidc).await?;
+                self.validate_jwt(jwt.as_str(), &jwks).map_err(|err| {
+                    anyhow::anyhow!("validation failed after refreshing JWKS: {:?}", err)
+                })
+            }
+            Err(ValidationError::MissingKid) => anyhow::bail!("missing kid header field"),
+            Err(ValidationError::Other(err)) => Err(err),
+        }
+    }
+
+    async fn fetch_well_known(&self) -> anyhow::Result<OidcDiscovery> {
+        {
+            let cache = self.well_known_cache.read().await;
+            if let Some((oidc, fetched_at)) = &*cache {
+                if fetched_at.elapsed() < Duration::from_secs(3600) {
+                    return Ok(oidc.clone());
+                }
+            }
+        }
+        let well_known = ".well-known/openid-configuration";
+        let well_known = format!("{}/{well_known}", self.issuer);
+        let response = self.client.get(well_known).send().await?;
+        let bytes = response.bytes().await?;
+        let oidc = serde_json::from_slice::<OidcDiscovery>(&bytes)?;
+        let mut cache = self.well_known_cache.write().await;
+        cache.replace((oidc.clone(), Instant::now()));
+        Ok(oidc)
+    }
+
+    async fn invalidate_cache(&self) {
+        let mut cache = self.jwks_cache.write().await;
+        cache.take();
+    }
+
+    async fn fetch_jwks(&self, oidc: &OidcDiscovery) -> anyhow::Result<Jwks> {
+        {
+            let cache = self.jwks_cache.read().await;
+            if let Some((jwks, fetched_at)) = cache.as_ref() {
+                if fetched_at.elapsed() < Duration::from_secs(300) {
+                    return Ok(jwks.clone());
+                }
+            }
+        }
+
+        let jwks_resp = self.client.get(&oidc.jwks_uri).send().await?;
+        let bytes = jwks_resp.bytes().await?;
+        let jwks = serde_json::from_slice::<Jwks>(&bytes)?;
+        let mut cache = self.jwks_cache.write().await;
+        cache.replace((jwks.clone(), Instant::now()));
+        Ok(jwks)
+    }
+
+    fn validate_jwt(&self, jwt: &str, jwks: &Jwks) -> Result<Claims, ValidationError> {
+        // JWT decode
+        let header = jsonwebtoken::decode_header(jwt)?;
+
+        // Check which key
+        let kid = header.kid.ok_or_else(|| ValidationError::MissingKid)?;
+        let jwk = jwks
+            .keys
+            .iter()
+            .find(|k| match k {
+                Jwk::RSA { kid: mykid, .. } => *mykid == kid,
+                Jwk::EC { kid: mykid, .. } => *mykid == kid,
+            })
+            .ok_or_else(|| ValidationError::UnknownKid(kid))?;
+
+        let (alg, key) = match jwk {
+            Jwk::RSA { n, e, .. } => (
+                Algorithm::RS256,
+                jsonwebtoken::DecodingKey::from_rsa_components(n, e)?,
+            ),
+            Jwk::EC { x, y, crv, .. } => {
+                let alg = match crv.as_str() {
+                    "P-256" => Algorithm::ES256,
+                    "P-384" => Algorithm::ES384,
+                    _ => {
+                        return Err(ValidationError::Other(anyhow::anyhow!(
+                            "unsupported curve: {crv}"
+                        )));
+                    }
+                };
+                (alg, jsonwebtoken::DecodingKey::from_ec_components(x, y)?)
+            }
+        };
+
+        // Verify
+        let mut validation = jsonwebtoken::Validation::new(alg);
+        validation.set_issuer(&[&self.issuer]);
+        validation.set_audience(&[&self.audience]);
+        validation.set_required_spec_claims(&["exp", "iss", "aud"]);
+        let claims = jsonwebtoken::decode::<Claims>(&jwt, &key, &validation)?;
+        Ok(claims.claims)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::oidc::{Claims, Jwk, Jwks, OidcValidator};
+    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use rsa::RsaPrivateKey;
+    use rsa::pkcs8::DecodePrivateKey;
+    use rsa::traits::PublicKeyParts;
+
+    #[test]
+    fn test_validate_token_rsa() {
+        let (claims, oidc, private_key, jwks) = create_test_setup();
+
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some("test-kid".to_string());
+
+        let key = EncodingKey::from_rsa_pem(private_key.as_bytes()).unwrap();
+        let token = encode(&header, &claims, &key).unwrap();
+
+        // Execute
+        let res = oidc.validate_jwt(token.as_str(), &jwks).unwrap();
+
+        // Assert
+        assert_eq!(res.sub, "user123");
+        assert_eq!(res.iss, "issuer");
+        assert_eq!(res.aud, "audience");
+        assert_eq!(res.email, "test@example.com");
+    }
+
+    #[test]
+    fn test_validate_token_ec() {
+        let (claims, oidc, _, _) = create_test_setup();
+        let (ec_private_key, jwks) = create_test_elliptic_curve();
+
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some("test-kid".to_string());
+
+        let key = EncodingKey::from_ec_pem(ec_private_key.as_bytes()).unwrap();
+        let token = encode(&header, &claims, &key).unwrap();
+
+        // Execute
+        let res = oidc.validate_jwt(token.as_str(), &jwks).unwrap();
+
+        // Assert
+        assert_eq!(res.sub, "user123");
+        assert_eq!(res.iss, "issuer");
+        assert_eq!(res.aud, "audience");
+        assert_eq!(res.email, "test@example.com");
+    }
+
+    #[test]
+    fn test_invalid_token() {
+        let (_, oidc, _, jwks) = create_test_setup();
+
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some("test-kid".to_string());
+
+        let token = "invalid.token.value".to_string();
+
+        // Execute
+        let res = oidc.validate_jwt(token.as_str(), &jwks);
+
+        // Assert
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_token_invalid_audience() {
+        let (mut claims, oidc, private_key, jwks) = create_test_setup();
+        claims.aud = "invalid-audience".into();
+
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some("test-kid".to_string());
+
+        let key = EncodingKey::from_rsa_pem(private_key.as_bytes()).unwrap();
+        let token = encode(&header, &claims, &key).unwrap();
+
+        // Execute
+        let res = oidc.validate_jwt(token.as_str(), &jwks);
+
+        // Assert
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_token_invalid_issuer() {
+        let (mut claims, oidc, private_key, jwks) = create_test_setup();
+        claims.iss = "invalid-issuer".into();
+
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some("test-kid".to_string());
+
+        let key = EncodingKey::from_rsa_pem(private_key.as_bytes()).unwrap();
+        let token = encode(&header, &claims, &key).unwrap();
+
+        // Execute
+        let res = oidc.validate_jwt(token.as_str(), &jwks);
+
+        // Assert
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_missing_kid_header() {
+        let (claims, oidc, private_key, jwks) = create_test_setup();
+
+        let header = Header::new(Algorithm::RS256);
+
+        let key = EncodingKey::from_rsa_pem(private_key.as_bytes()).unwrap();
+        let token = encode(&header, &claims, &key).unwrap();
+
+        // Execute
+        let res = oidc.validate_jwt(token.as_str(), &jwks);
+
+        // Assert
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_missing_kid_in_jwks() {
+        let (claims, oidc, private_key, mut jwks) = create_test_setup();
+
+        // Remove the key from JWKS
+        jwks.keys.clear();
+
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some("test-kid".to_string());
+
+        let key = EncodingKey::from_rsa_pem(private_key.as_bytes()).unwrap();
+        let token = encode(&header, &claims, &key).unwrap();
+
+        // Execute
+        let res = oidc.validate_jwt(token.as_str(), &jwks);
+
+        // Assert
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_expired_token() {
+        let (mut claims, oidc, private_key, jwks) = create_test_setup();
+        claims.exp = 1; // Set expiration in the past
+
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some("test-kid".to_string());
+
+        let key = EncodingKey::from_rsa_pem(private_key.as_bytes()).unwrap();
+        let token = encode(&header, &claims, &key).unwrap();
+
+        // Execute
+        let res = oidc.validate_jwt(token.as_str(), &jwks);
+
+        // Assert
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_reject_algorithm() {
+        let (claims, oidc, _, jwks) = create_test_setup();
+
+        // Manually build a token with HS256 header but garbage signature
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"alg":"HS256","kid":"test-kid"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_string(&claims).unwrap());
+        let token = format!("{header}.{payload}.fakesignature");
+
+        // Execute
+        let res = oidc.validate_jwt(token.as_str(), &jwks);
+
+        // Assert
+        assert!(res.is_err());
+    }
+
+    fn create_test_setup() -> (Claims, OidcValidator, String, Jwks) {
+        let (private_key, jwks) = create_test_jwks();
+        (
+            Claims {
+                iss: "issuer".into(),
+                sub: "user123".into(),
+                aud: "audience".into(),
+                email: "test@example.com".into(),
+                exp: 9999999999,
+            },
+            OidcValidator::new("issuer".to_string(), "audience".to_string()),
+            private_key,
+            jwks,
+        )
+    }
+
+    fn create_test_jwks() -> (String, Jwks) {
+        let private_key = "-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDZePvklQRubCg/
+2mCTRyEPfmkwjdhRKBJ8ykf7dhj1jFkIPhzhIhpnXK4xYcozcdnBV/DPIb1O2lH9
+bCe3oRpcsN9eb6GYglOe3c1hX61Wo/nRv/hF8hlvkrnCg6RyQuzR/q8LfLYk2UEw
+HcYxU9nGGo8CVCKIA++qF4RY/G7WraWkX8AAf61TrSEC3v2VYpi45UXEpILZmrUN
+B7V42yH2ig+OzUUyCzuNr7wdH954HxhTDK45FuwbD1WN+Zg6UCSJH5JPm5t2CrbP
+qbcyoaglDGgoiUZO+Xdpet/feMwfh5Zc3tkOjZfcl/hWFGrsDBnylC8dnFYITTo+
+u260Fe7fAgMBAAECggEAXQhImey1zJcwUMCW9+pB1mL5lO/ZTj6aShAu4wAOhVzY
+6ZHIwPbZ3MXlLvLqkT9vLCr2tWV1mroCwSr3grLEmEqCA+A1fQyjwR6ZscJAYQQc
+5wH8r8912ikmlnPCca73qI4PTBa5xOG75V2XX5rDWuAZtaFQdGdaq6UL1RWIRQWR
+q3HK/OC1zuQPaq8rumHm9VadOv1har73gYKMNKkpgDRr4ws+ik9pBnQqdUFxiNal
+W57+ao1c/HpRIWnqItmBUIfBwl7Gh6s8d6IZa+dD7jeN2Fi5HYP1VEBtyb0T+aPI
+MB6oEKvPGBHC2EO9vNnYSpfYN1ljG6k7ewffySKiIQKBgQD9D6DMnoIUxyZtJj/a
+dSJeqG7jlk1iuzJWP+bKAklaztX8+4S//3FM3pSXcGIr0iz6tScHhCovNrSjUVCu
+hYxtCL9uR8SGJrupHCNz9vmaLk1HlF/NIiq+pM/qnOp/+L7Bi6iu3abiNE7SRNVm
+aKVgZFr6F/DRwB9PTqi4RqD8cwKBgQDb/4xg7ooeFgYUMDPXwwaK3QWJNgXth/8W
+E6N6pXRRyhwz9qyekWaod4qbjIb+x+lweFjB+fVAlRpAnJ5J1N9v98z/0MGimcQc
++pPgaoLWbuFZoYGqpS6unM218XtctXOHra8PIe1lTf1MG3xloF51ucJnZZGP2cNG
+LGrbYZB05QKBgQDrhtQeHZjsRb5Z8DOV21c1yoYKhCVaMuhSpf7jHOWxArjfUCjp
+mZGV/cNGf26fYmpCnL/KmxO4Ba5yIoh5JgrgoDerKFickwguCOZmVANToKyEZnAT
+uC0YasSok4sduCGyeY1x0xIzjoOd6DrFqbfh0wVpp0aXsbxyT79wYywKSQKBgAyq
+WK2X7hGvWOg+oi1wx+aktNXia1LyemgN92JvNhQjW55OPD/gxRU71JoB7B+s6K6V
+7x4zwr/WFa3UlnRPshFjJcUwgoVW7uhwMKVB3Ih117luR+XIHrjkxB8OaPi8ZYtR
+H3vyixVC+Ssxhebf5bBHYn7LZSbv9YMLuZcptcRVAoGAKoZHmYDPvTs71LLv4I5q
+gS5ZBeVNhXa8kITMuOumdxv7UVY2XLx8wvpZOZKT6td5k+dhSlaW9ClPyBXA60V0
+lRsvB0LPb4MH0ye3t9mGe/XoaBWKtheejyQ9CUrDVnQQRxfXXnUkXGMwNgw6RPPd
+Nc3GLyMxuf/cuSIU05L70Os=
+-----END PRIVATE KEY-----";
+        let rsa_key = RsaPrivateKey::from_pkcs8_pem(private_key).unwrap();
+        let pub_key = rsa_key.to_public_key();
+        let n = URL_SAFE_NO_PAD.encode(pub_key.n().to_bytes_be());
+        let e = URL_SAFE_NO_PAD.encode(pub_key.e().to_bytes_be());
+        (
+            private_key.into(),
+            Jwks {
+                keys: vec![Jwk::RSA {
+                    kid: "test-kid".into(),
+                    n: n.into(),
+                    e: e.into(),
+                }],
+            },
+        )
+    }
+
+    use p256::SecretKey;
+    use p256::elliptic_curve::sec1::ToEncodedPoint;
+
+    fn create_test_elliptic_curve() -> (String, Jwks) {
+        let priv_key = "-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgVqWno0lr4PbJz2f4
+wNMbbCqMmVl0SdG65jMBSGM9lc+hRANCAARA4l5fHhXZKFQfYg/MtSV3gYcjuY1X
++pxhervZB6m/jLfvVDLZO90N7VhNedAhg4J/GU9jojkfDFQ9k2MrFNPb
+-----END PRIVATE KEY-----";
+
+        let ec_key = SecretKey::from_pkcs8_pem(priv_key).unwrap();
+        let pub_key = ec_key.public_key().to_encoded_point(false);
+        let x = URL_SAFE_NO_PAD.encode(pub_key.x().unwrap());
+        let y = URL_SAFE_NO_PAD.encode(pub_key.y().unwrap());
+
+        (
+            priv_key.into(),
+            Jwks {
+                keys: vec![Jwk::EC {
+                    kid: "test-kid".into(),
+                    x,
+                    y,
+                    crv: "P-256".into(),
+                }],
+            },
+        )
+    }
 }

--- a/crates/cloudsync-server/src/oidc.rs
+++ b/crates/cloudsync-server/src/oidc.rs
@@ -6,11 +6,18 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tokio::sync::RwLock;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum Audience {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
     pub sub: String,
     pub iss: String,
-    pub aud: String,
+    pub aud: Audience,
     pub email: String,
     pub exp: usize,
 }
@@ -64,6 +71,7 @@ impl From<jsonwebtoken::errors::Error> for ValidationError {
 #[derive(Clone)]
 pub struct OidcValidator {
     pub issuer: String,
+    pub discovery_url: String,
     pub audience: String,
     pub client: Client,
     well_known_cache: Arc<RwLock<Option<(OidcDiscovery, std::time::Instant)>>>,
@@ -71,9 +79,10 @@ pub struct OidcValidator {
 }
 
 impl OidcValidator {
-    pub fn new(issuer: String, audience: String) -> Self {
+    pub fn new(issuer: String, discovery_url: String, audience: String) -> Self {
         OidcValidator {
-            issuer,
+            issuer: issuer.trim_end_matches('/').to_string(),
+            discovery_url: discovery_url.trim_end_matches('/').to_string(),
             audience,
             client: reqwest::Client::new(),
             well_known_cache: Arc::new(RwLock::new(None)),
@@ -120,7 +129,7 @@ impl OidcValidator {
             }
         }
         let well_known = ".well-known/openid-configuration";
-        let well_known = format!("{}/{well_known}", self.issuer);
+        let well_known = format!("{}/{well_known}", self.discovery_url);
         let response = self.client.get(well_known).send().await?;
         let bytes = response.bytes().await?;
         let oidc = serde_json::from_slice::<OidcDiscovery>(&bytes)?;
@@ -198,7 +207,7 @@ impl OidcValidator {
 
 #[cfg(test)]
 mod test {
-    use crate::oidc::{Claims, Jwk, Jwks, OidcValidator};
+    use crate::oidc::{Audience, Claims, Jwk, Jwks, OidcValidator};
     use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 
     use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
@@ -222,7 +231,7 @@ mod test {
         // Assert
         assert_eq!(res.sub, "user123");
         assert_eq!(res.iss, "issuer");
-        assert_eq!(res.aud, "audience");
+        assert_eq!(res.aud, Audience::Single("audience".to_string()));
         assert_eq!(res.email, "test@example.com");
     }
 
@@ -243,7 +252,7 @@ mod test {
         // Assert
         assert_eq!(res.sub, "user123");
         assert_eq!(res.iss, "issuer");
-        assert_eq!(res.aud, "audience");
+        assert_eq!(res.aud, Audience::Single("audience".to_string()));
         assert_eq!(res.email, "test@example.com");
     }
 
@@ -266,7 +275,7 @@ mod test {
     #[test]
     fn test_token_invalid_audience() {
         let (mut claims, oidc, private_key, jwks) = create_test_setup();
-        claims.aud = "invalid-audience".into();
+        claims.aud = Audience::Single("invalid-audience".to_string());
 
         let mut header = Header::new(Algorithm::RS256);
         header.kid = Some("test-kid".to_string());
@@ -377,11 +386,15 @@ mod test {
             Claims {
                 iss: "issuer".into(),
                 sub: "user123".into(),
-                aud: "audience".into(),
+                aud: Audience::Single("audience".to_string()),
                 email: "test@example.com".into(),
                 exp: 9999999999,
             },
-            OidcValidator::new("issuer".to_string(), "audience".to_string()),
+            OidcValidator::new(
+                "issuer".to_string(),
+                "discovery_url".to_string(),
+                "audience".to_string(),
+            ),
             private_key,
             jwks,
         )

--- a/crates/cloudsync-server/tests/integration_test.rs
+++ b/crates/cloudsync-server/tests/integration_test.rs
@@ -19,13 +19,15 @@ async fn test_range_download() {
         .unwrap()
         .to_string();
     let server = cloudsync_server::app::bootstrap_app(ServerConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
         storage_dir: storage_dir_str,
         staging_dir: staging_dir.to_str().unwrap().to_string(),
         token: token.to_string(),
         dbname: dbname.to_string(),
         default_tenant_id: "tenant".to_string(),
         default_user_id: "user".to_string(),
-        oidc_issuer: None,
+        oidc_config: None,
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -74,13 +76,15 @@ async fn test_chunked_upload() {
         .unwrap()
         .to_string();
     let server = cloudsync_server::app::bootstrap_app(ServerConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
         storage_dir: storage_dir_str,
         staging_dir: staging_dir.to_str().unwrap().to_string(),
         token: token.to_string(),
         dbname: dbname.to_string(),
         default_tenant_id: "tenant".to_string(),
         default_user_id: "user".to_string(),
-        oidc_issuer: None,
+        oidc_config: None,
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/cloudsync-server/tests/integration_test.rs
+++ b/crates/cloudsync-server/tests/integration_test.rs
@@ -25,6 +25,7 @@ async fn test_range_download() {
         dbname: dbname.to_string(),
         default_tenant_id: "tenant".to_string(),
         default_user_id: "user".to_string(),
+        oidc_issuer: None,
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -79,6 +80,7 @@ async fn test_chunked_upload() {
         dbname: dbname.to_string(),
         default_tenant_id: "tenant".to_string(),
         default_user_id: "user".to_string(),
+        oidc_issuer: None,
     })
     .unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,30 @@ services:
       # Not needed when OIDC is configured (users get their own tenants).
       - CLOUDSYNC_DEFAULT_TENANT_ID=${CLOUDSYNC_DEFAULT_TENANT_ID:-default-tenant}
       - CLOUDSYNC_DEFAULT_USER_ID=${CLOUDSYNC_DEFAULT_USER_ID:-default-user}
+      # OIDC config
+      - CLOUDSYNC_OIDC_ISSUER=https://auth.devchris.dev/realms/cloudsync
+      - CLOUDSYNC_OIDC_DISCOVERY_URL=http://keycloak:8080/realms/cloudsync
+      - CLOUDSYNC_OIDC_AUDIENCE=cloudsync
       - RUST_LOG=cloudsync_server=info
+    restart: unless-stopped
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0.3
+    environment:
+      - KEYCLOAK_ADMIN=$CLOUDSYNC_KC_ADMIN
+      - KEYCLOAK_ADMIN_PASSWORD=$CLOUDSYNC_KC_ADMIN_PASSWORD
+      - KC_HOSTNAME=https://auth.devchris.dev
+      - KC_PROXY_HEADERS=xforwarded
+      - KC_HTTP_ENABLED=true
+    ports:
+      - "8080:8080"
+    # --import-realm bootstraps the cloudsync realm from realm-cloudsync.json
+    # on first boot only; subsequent boots preserve in-place changes (users,
+    # rotated passwords). Treat the JSON as bootstrap, not source of truth.
+    command: ["start", "--import-realm"]
+    volumes:
+      - ${CLOUDSYNC_KEYCLOAK_DATA_DIR}:/opt/keycloak/data
+      - ./keycloak/realm-cloudsync.json:/opt/keycloak/data/import/realm-cloudsync.json:ro
     restart: unless-stopped
 
   reverse-proxy:

--- a/docs/plan-oidc-hardening.md
+++ b/docs/plan-oidc-hardening.md
@@ -1,0 +1,42 @@
+# OIDC Validation Hardening Plan
+
+## 1. Algorithm flexibility
+
+- Support a configurable list of allowed algorithms (e.g. `RS256`, `ES256`)
+- Reject tokens with any `alg` not in the whitelist (prevents algorithm confusion attacks)
+- Set `Validation.algorithms` to the allowed list
+
+## 2. Claims validation
+
+- **Issuer (`iss`)**: verify it matches the configured issuer URL
+- **Audience (`aud`)**: verify it contains our client ID (prevents cross-service token reuse)
+- **Expiry (`exp`) / Not Before (`nbf`)**: confirm `jsonwebtoken::Validation` has these enabled (on by default, but be explicit)
+
+## 3. Graceful error handling
+
+- Handle missing `kid` in token header — return error instead of panic
+- Handle unknown `kid` (not found in JWKS) — return clear error
+
+## 4. JWKS caching
+
+- Cache the JWKS response in memory (avoid fetching on every request)
+- Use a TTL (e.g. 5-10 minutes) to bound staleness
+- On cache hit, use cached keys directly
+
+## 5. JWKS refresh on failure
+
+- If validation fails due to unknown `kid`, refetch JWKS once and retry
+- This handles key rotation: Keycloak adds a new key, old cache doesn't have it
+- Limit refetches (at most once per N seconds) to prevent abuse triggering constant fetches
+
+## 6. HTTP hardening
+
+- Set a timeout on all outgoing requests (discovery + JWKS fetch), e.g. 5 seconds
+- Limit response body size for JWKS/discovery (e.g. 512KB) to prevent resource exhaustion
+- Reuse a single `reqwest::Client` (connection pooling)
+
+## 7. Discovery caching
+
+- Cache the `.well-known/openid-configuration` response
+- Rarely changes — longer TTL than JWKS (e.g. 1 hour)
+- Refetch on startup or on JWKS fetch failure (in case `jwks_uri` changed)

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -28,11 +28,33 @@ Verify: `ssh -o PubkeyAuthentication=no root@<server-ip>` should return `Permiss
 
 - Mount the Hetzner volume to `/mnt/volume-cloudsync`
 - Remove any duplicate mount points from `/etc/fstab`
-- Create the data directory:
+- Create one subdirectory per service that needs persistent state:
 
 ```sh
-mkdir -p /mnt/volume-cloudsync/cloudsync
+mkdir -p /mnt/volume-cloudsync/{cloudsync,caddy,keycloak}
 ```
+
+| Directory  | Maps to env var               | Backs                                  |
+| ---------- | ----------------------------- | -------------------------------------- |
+| `cloudsync/` | `CLOUDSYNC_MOUNT_DIR`         | cloudsync server: file storage + redb  |
+| `caddy/`     | `CLOUDSYNC_CADDY_MOUNT_DIR`   | caddy: Let's Encrypt certs, state      |
+| `keycloak/`  | `CLOUDSYNC_KEYCLOAK_DATA_DIR` | keycloak: H2 database, signing keys    |
+
+### Permissions
+
+Each container's process needs write access to its bind-mounted directory.
+Containers running as root inside the image (cloudsync, caddy) can write to
+`root:root 755` dirs, so they need no chown. Keycloak's official image runs
+as uid 1000 and will fail to start if it can't write to its data dir:
+
+```sh
+chown 1000:1000 /mnt/volume-cloudsync/keycloak
+```
+
+If we ever harden the cloudsync or caddy images to run as a non-root user
+(see roadmap), the same chown becomes required for those dirs too — pick a
+uid, declare it in the Dockerfile (or `user:` in compose), and `chown` the
+matching host dir.
 
 ## 4. Deploy Key for CI/CD
 

--- a/keycloak/realm-cloudsync.json
+++ b/keycloak/realm-cloudsync.json
@@ -1,0 +1,2222 @@
+{
+    "id": "fd58fe4a-d3d2-4fcc-b5f1-1e1b2598e591",
+    "realm": "cloudsync",
+    "notBefore": 0,
+    "defaultSignatureAlgorithm": "RS256",
+    "revokeRefreshToken": false,
+    "refreshTokenMaxReuse": 0,
+    "accessTokenLifespan": 300,
+    "accessTokenLifespanForImplicitFlow": 900,
+    "ssoSessionIdleTimeout": 1800,
+    "ssoSessionMaxLifespan": 36000,
+    "ssoSessionIdleTimeoutRememberMe": 0,
+    "ssoSessionMaxLifespanRememberMe": 0,
+    "offlineSessionIdleTimeout": 2592000,
+    "offlineSessionMaxLifespanEnabled": false,
+    "offlineSessionMaxLifespan": 5184000,
+    "clientSessionIdleTimeout": 0,
+    "clientSessionMaxLifespan": 0,
+    "clientOfflineSessionIdleTimeout": 0,
+    "clientOfflineSessionMaxLifespan": 0,
+    "accessCodeLifespan": 60,
+    "accessCodeLifespanUserAction": 300,
+    "accessCodeLifespanLogin": 1800,
+    "actionTokenGeneratedByAdminLifespan": 43200,
+    "actionTokenGeneratedByUserLifespan": 300,
+    "oauth2DeviceCodeLifespan": 600,
+    "oauth2DevicePollingInterval": 5,
+    "enabled": true,
+    "sslRequired": "external",
+    "registrationAllowed": false,
+    "registrationEmailAsUsername": false,
+    "rememberMe": false,
+    "verifyEmail": false,
+    "loginWithEmailAllowed": true,
+    "duplicateEmailsAllowed": false,
+    "resetPasswordAllowed": false,
+    "editUsernameAllowed": false,
+    "bruteForceProtected": false,
+    "permanentLockout": false,
+    "maxTemporaryLockouts": 0,
+    "maxFailureWaitSeconds": 900,
+    "minimumQuickLoginWaitSeconds": 60,
+    "waitIncrementSeconds": 60,
+    "quickLoginCheckMilliSeconds": 1000,
+    "maxDeltaTimeSeconds": 43200,
+    "failureFactor": 30,
+    "roles": {
+        "realm": [
+            {
+                "id": "f5899c2c-60d5-4c07-9ec3-c84797c5f746",
+                "name": "uma_authorization",
+                "description": "${role_uma_authorization}",
+                "composite": false,
+                "clientRole": false,
+                "containerId": "fd58fe4a-d3d2-4fcc-b5f1-1e1b2598e591",
+                "attributes": {}
+            },
+            {
+                "id": "e10f42ff-2aa4-4f1a-a06b-2e797c0cd0d6",
+                "name": "default-roles-cloudsync",
+                "description": "${role_default-roles}",
+                "composite": true,
+                "composites": {
+                    "realm": [
+                        "offline_access",
+                        "uma_authorization"
+                    ],
+                    "client": {
+                        "account": [
+                            "view-profile",
+                            "manage-account"
+                        ]
+                    }
+                },
+                "clientRole": false,
+                "containerId": "fd58fe4a-d3d2-4fcc-b5f1-1e1b2598e591",
+                "attributes": {}
+            },
+            {
+                "id": "7b84a6a8-e567-4e70-aa6e-f2e358565843",
+                "name": "offline_access",
+                "description": "${role_offline-access}",
+                "composite": false,
+                "clientRole": false,
+                "containerId": "fd58fe4a-d3d2-4fcc-b5f1-1e1b2598e591",
+                "attributes": {}
+            }
+        ],
+        "client": {
+            "realm-management": [
+                {
+                    "id": "ecabc228-ba77-4524-9348-2d004070332f",
+                    "name": "manage-realm",
+                    "description": "${role_manage-realm}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "addb3065-dd72-4dce-ae7c-be7d9ed4b943",
+                    "name": "view-clients",
+                    "description": "${role_view-clients}",
+                    "composite": true,
+                    "composites": {
+                        "client": {
+                            "realm-management": [
+                                "query-clients"
+                            ]
+                        }
+                    },
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "6cdd3256-38f0-44d9-b3f7-500f181ee934",
+                    "name": "realm-admin",
+                    "description": "${role_realm-admin}",
+                    "composite": true,
+                    "composites": {
+                        "client": {
+                            "realm-management": [
+                                "manage-realm",
+                                "view-clients",
+                                "view-authorization",
+                                "view-users",
+                                "manage-clients",
+                                "query-groups",
+                                "view-identity-providers",
+                                "manage-authorization",
+                                "create-client",
+                                "query-users",
+                                "view-realm",
+                                "query-clients",
+                                "view-events",
+                                "query-realms",
+                                "manage-users",
+                                "impersonation",
+                                "manage-identity-providers",
+                                "manage-events"
+                            ]
+                        }
+                    },
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "c05c171f-98ac-4e1e-8ae3-97edfa8b9779",
+                    "name": "view-authorization",
+                    "description": "${role_view-authorization}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "5b35d022-9f30-4cd9-9fdc-4c089d76dc23",
+                    "name": "view-users",
+                    "description": "${role_view-users}",
+                    "composite": true,
+                    "composites": {
+                        "client": {
+                            "realm-management": [
+                                "query-users",
+                                "query-groups"
+                            ]
+                        }
+                    },
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "aa1d0d1d-54fc-4983-a45d-3ce5b734e0b1",
+                    "name": "manage-clients",
+                    "description": "${role_manage-clients}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "c250b444-2d8c-4235-80c6-f28575242ee4",
+                    "name": "query-groups",
+                    "description": "${role_query-groups}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "5471c291-14d8-426b-b23c-70185902cad3",
+                    "name": "view-identity-providers",
+                    "description": "${role_view-identity-providers}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "2fe25cf4-d091-4555-b117-43574ea444b0",
+                    "name": "manage-authorization",
+                    "description": "${role_manage-authorization}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "4ad41f7c-f461-450d-bd9c-fd883b9e016b",
+                    "name": "create-client",
+                    "description": "${role_create-client}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "9f6c9d6d-2bea-4a28-96b6-c8de65be0b41",
+                    "name": "query-users",
+                    "description": "${role_query-users}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "b1cbb840-0cf3-4805-b22a-d2f64e5ae444",
+                    "name": "view-realm",
+                    "description": "${role_view-realm}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "25e1ea02-fd9c-48bb-bd0b-8ea1288fbc9f",
+                    "name": "query-clients",
+                    "description": "${role_query-clients}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "6578194f-778d-4b28-9296-b28f569aec68",
+                    "name": "view-events",
+                    "description": "${role_view-events}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "cec84d7d-cc23-4106-befe-af7a548c25d6",
+                    "name": "impersonation",
+                    "description": "${role_impersonation}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "6cbaf98a-6529-4094-9f1e-04d3a7dd677c",
+                    "name": "manage-users",
+                    "description": "${role_manage-users}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "56601ce6-5063-407f-a299-dc89a33168f5",
+                    "name": "query-realms",
+                    "description": "${role_query-realms}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "610f9591-4af1-4ac6-9dc6-20a9de1d2448",
+                    "name": "manage-identity-providers",
+                    "description": "${role_manage-identity-providers}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                },
+                {
+                    "id": "0ec60868-3270-4aaf-a10b-8909cc334302",
+                    "name": "manage-events",
+                    "description": "${role_manage-events}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+                    "attributes": {}
+                }
+            ],
+            "security-admin-console": [],
+            "cloudsync": [],
+            "admin-cli": [],
+            "account-console": [],
+            "broker": [
+                {
+                    "id": "1d889853-a71f-4496-a430-9b09f943864e",
+                    "name": "read-token",
+                    "description": "${role_read-token}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "21ee212b-371d-423e-9b71-04b0c5e126ac",
+                    "attributes": {}
+                }
+            ],
+            "account": [
+                {
+                    "id": "86b6da1e-6466-4a05-9219-32de1231d464",
+                    "name": "manage-consent",
+                    "description": "${role_manage-consent}",
+                    "composite": true,
+                    "composites": {
+                        "client": {
+                            "account": [
+                                "view-consent"
+                            ]
+                        }
+                    },
+                    "clientRole": true,
+                    "containerId": "69176403-a865-4c76-856b-11e09b4ffde1",
+                    "attributes": {}
+                },
+                {
+                    "id": "4e76947d-b3b0-4d5d-868b-db9ff7e1ff78",
+                    "name": "delete-account",
+                    "description": "${role_delete-account}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "69176403-a865-4c76-856b-11e09b4ffde1",
+                    "attributes": {}
+                },
+                {
+                    "id": "60a6b67f-0b89-4076-89f5-ffdfdf12c045",
+                    "name": "view-applications",
+                    "description": "${role_view-applications}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "69176403-a865-4c76-856b-11e09b4ffde1",
+                    "attributes": {}
+                },
+                {
+                    "id": "34da2e94-c78e-4b07-9484-f2b548641f78",
+                    "name": "manage-account-links",
+                    "description": "${role_manage-account-links}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "69176403-a865-4c76-856b-11e09b4ffde1",
+                    "attributes": {}
+                },
+                {
+                    "id": "eda979e1-b5ad-4c60-a32d-defcd1f0016f",
+                    "name": "view-profile",
+                    "description": "${role_view-profile}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "69176403-a865-4c76-856b-11e09b4ffde1",
+                    "attributes": {}
+                },
+                {
+                    "id": "928c029b-85b8-4c95-b914-0c9d667ca6a2",
+                    "name": "manage-account",
+                    "description": "${role_manage-account}",
+                    "composite": true,
+                    "composites": {
+                        "client": {
+                            "account": [
+                                "manage-account-links"
+                            ]
+                        }
+                    },
+                    "clientRole": true,
+                    "containerId": "69176403-a865-4c76-856b-11e09b4ffde1",
+                    "attributes": {}
+                },
+                {
+                    "id": "5917a2b8-8782-4bf6-b643-41ca936949c5",
+                    "name": "view-consent",
+                    "description": "${role_view-consent}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "69176403-a865-4c76-856b-11e09b4ffde1",
+                    "attributes": {}
+                },
+                {
+                    "id": "cd915f9c-43ce-4cd8-bcd8-b14de2f53002",
+                    "name": "view-groups",
+                    "description": "${role_view-groups}",
+                    "composite": false,
+                    "clientRole": true,
+                    "containerId": "69176403-a865-4c76-856b-11e09b4ffde1",
+                    "attributes": {}
+                }
+            ]
+        }
+    },
+    "groups": [],
+    "defaultRole": {
+        "id": "e10f42ff-2aa4-4f1a-a06b-2e797c0cd0d6",
+        "name": "default-roles-cloudsync",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "clientRole": false,
+        "containerId": "fd58fe4a-d3d2-4fcc-b5f1-1e1b2598e591"
+    },
+    "requiredCredentials": [
+        "password"
+    ],
+    "otpPolicyType": "totp",
+    "otpPolicyAlgorithm": "HmacSHA1",
+    "otpPolicyInitialCounter": 0,
+    "otpPolicyDigits": 6,
+    "otpPolicyLookAheadWindow": 1,
+    "otpPolicyPeriod": 30,
+    "otpPolicyCodeReusable": false,
+    "otpSupportedApplications": [
+        "totpAppFreeOTPName",
+        "totpAppGoogleName",
+        "totpAppMicrosoftAuthenticatorName"
+    ],
+    "localizationTexts": {},
+    "webAuthnPolicyRpEntityName": "keycloak",
+    "webAuthnPolicySignatureAlgorithms": [
+        "ES256"
+    ],
+    "webAuthnPolicyRpId": "",
+    "webAuthnPolicyAttestationConveyancePreference": "not specified",
+    "webAuthnPolicyAuthenticatorAttachment": "not specified",
+    "webAuthnPolicyRequireResidentKey": "not specified",
+    "webAuthnPolicyUserVerificationRequirement": "not specified",
+    "webAuthnPolicyCreateTimeout": 0,
+    "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+    "webAuthnPolicyAcceptableAaguids": [],
+    "webAuthnPolicyExtraOrigins": [],
+    "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+    "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+        "ES256"
+    ],
+    "webAuthnPolicyPasswordlessRpId": "",
+    "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+    "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+    "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+    "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+    "webAuthnPolicyPasswordlessCreateTimeout": 0,
+    "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+    "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+    "webAuthnPolicyPasswordlessExtraOrigins": [],
+    "scopeMappings": [
+        {
+            "clientScope": "offline_access",
+            "roles": [
+                "offline_access"
+            ]
+        }
+    ],
+    "clientScopeMappings": {
+        "account": [
+            {
+                "client": "account-console",
+                "roles": [
+                    "manage-account",
+                    "view-groups"
+                ]
+            }
+        ]
+    },
+    "clients": [
+        {
+            "id": "69176403-a865-4c76-856b-11e09b4ffde1",
+            "clientId": "account",
+            "name": "${client_account}",
+            "rootUrl": "${authBaseUrl}",
+            "baseUrl": "/realms/cloudsync/account/",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [
+                "/realms/cloudsync/account/*"
+            ],
+            "webOrigins": [],
+            "notBefore": 0,
+            "bearerOnly": false,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "serviceAccountsEnabled": false,
+            "publicClient": true,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {
+                "post.logout.redirect.uris": "+"
+            },
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        },
+        {
+            "id": "324a9ecd-e909-40e3-9cbf-f1f1dcb1449d",
+            "clientId": "account-console",
+            "name": "${client_account-console}",
+            "rootUrl": "${authBaseUrl}",
+            "baseUrl": "/realms/cloudsync/account/",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [
+                "/realms/cloudsync/account/*"
+            ],
+            "webOrigins": [],
+            "notBefore": 0,
+            "bearerOnly": false,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "serviceAccountsEnabled": false,
+            "publicClient": true,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {
+                "post.logout.redirect.uris": "+",
+                "pkce.code.challenge.method": "S256"
+            },
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "protocolMappers": [
+                {
+                    "id": "f4713f9c-7954-4f8a-9bb9-834655f6e6b9",
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {}
+                }
+            ],
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        },
+        {
+            "id": "cffb07fa-a735-49cf-886d-f28f7ae9188d",
+            "clientId": "admin-cli",
+            "name": "${client_admin-cli}",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [],
+            "webOrigins": [],
+            "notBefore": 0,
+            "bearerOnly": false,
+            "consentRequired": false,
+            "standardFlowEnabled": false,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": true,
+            "serviceAccountsEnabled": false,
+            "publicClient": true,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {},
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        },
+        {
+            "id": "21ee212b-371d-423e-9b71-04b0c5e126ac",
+            "clientId": "broker",
+            "name": "${client_broker}",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [],
+            "webOrigins": [],
+            "notBefore": 0,
+            "bearerOnly": true,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "serviceAccountsEnabled": false,
+            "publicClient": false,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {},
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        },
+        {
+            "id": "b4b1efe3-db0c-478b-9e94-b83e0d0c573f",
+            "clientId": "cloudsync",
+            "name": "cloudsync-client",
+            "description": "cloudsync keycloak client for testing",
+            "rootUrl": "",
+            "adminUrl": "",
+            "baseUrl": "",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [
+                "/*"
+            ],
+            "webOrigins": [
+                "/*"
+            ],
+            "notBefore": 0,
+            "bearerOnly": false,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": true,
+            "serviceAccountsEnabled": false,
+            "publicClient": true,
+            "frontchannelLogout": true,
+            "protocol": "openid-connect",
+            "attributes": {
+                "oidc.ciba.grant.enabled": "false",
+                "oauth2.device.authorization.grant.enabled": "false",
+                "backchannel.logout.session.required": "true",
+                "backchannel.logout.revoke.offline.tokens": "false"
+            },
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": true,
+            "nodeReRegistrationTimeout": -1,
+            "protocolMappers": [
+                {
+                    "id": "a9331992-07cc-4008-a94e-138ffbe14ea1",
+                    "name": "Cloudsync audience mapper",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "included.client.audience": "cloudsync",
+                        "id.token.claim": "false",
+                        "lightweight.claim": "false",
+                        "introspection.token.claim": "true",
+                        "access.token.claim": "true"
+                    }
+                }
+            ],
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        },
+        {
+            "id": "5d0ab9b6-b3b0-4e8a-b924-e9221a0b9837",
+            "clientId": "realm-management",
+            "name": "${client_realm-management}",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [],
+            "webOrigins": [],
+            "notBefore": 0,
+            "bearerOnly": true,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "serviceAccountsEnabled": false,
+            "publicClient": false,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {},
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        },
+        {
+            "id": "a72eaafb-e673-439e-b091-304b5825c897",
+            "clientId": "security-admin-console",
+            "name": "${client_security-admin-console}",
+            "rootUrl": "${authAdminUrl}",
+            "baseUrl": "/admin/cloudsync/console/",
+            "surrogateAuthRequired": false,
+            "enabled": true,
+            "alwaysDisplayInConsole": false,
+            "clientAuthenticatorType": "client-secret",
+            "redirectUris": [
+                "/admin/cloudsync/console/*"
+            ],
+            "webOrigins": [
+                "+"
+            ],
+            "notBefore": 0,
+            "bearerOnly": false,
+            "consentRequired": false,
+            "standardFlowEnabled": true,
+            "implicitFlowEnabled": false,
+            "directAccessGrantsEnabled": false,
+            "serviceAccountsEnabled": false,
+            "publicClient": true,
+            "frontchannelLogout": false,
+            "protocol": "openid-connect",
+            "attributes": {
+                "post.logout.redirect.uris": "+",
+                "pkce.code.challenge.method": "S256"
+            },
+            "authenticationFlowBindingOverrides": {},
+            "fullScopeAllowed": false,
+            "nodeReRegistrationTimeout": 0,
+            "protocolMappers": [
+                {
+                    "id": "586fc3ce-32c4-4ddc-8fd7-c405396b1405",
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "locale",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "locale",
+                        "jsonType.label": "String"
+                    }
+                }
+            ],
+            "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email"
+            ],
+            "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+            ]
+        }
+    ],
+    "clientScopes": [
+        {
+            "id": "27140ab3-fe24-4cfc-b7ed-3c90b23f1d4e",
+            "name": "profile",
+            "description": "OpenID Connect built-in scope: profile",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+                "consent.screen.text": "${profileScopeConsentText}"
+            },
+            "protocolMappers": [
+                {
+                    "id": "07ba510a-609d-4f90-972d-f0ccd1cdba29",
+                    "name": "middle name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "middleName",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "middle_name",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "4b70f5be-0aa7-4f27-bf29-124645aa17be",
+                    "name": "given name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "firstName",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "given_name",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "5ee5a8de-567e-47ee-8586-6a493cc6a900",
+                    "name": "website",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "website",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "website",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "39871149-9b74-4336-a8b8-45c8a98376a0",
+                    "name": "profile",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "profile",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "profile",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "96647953-f128-4f90-82c9-358adf30dd17",
+                    "name": "gender",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "gender",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "gender",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "4ca2582d-7aa0-4ddb-90e6-c2f27d21fb72",
+                    "name": "updated at",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "updatedAt",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "updated_at",
+                        "jsonType.label": "long"
+                    }
+                },
+                {
+                    "id": "f678ba23-0afb-4331-a9c3-943970932471",
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "locale",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "locale",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "245f807b-72a6-4ce0-bad1-bfdd503c3e46",
+                    "name": "picture",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "picture",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "picture",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "3c897eb0-1a48-4086-9bdd-3dcd6787ac7b",
+                    "name": "full name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-full-name-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "id.token.claim": "true",
+                        "introspection.token.claim": "true",
+                        "access.token.claim": "true",
+                        "userinfo.token.claim": "true"
+                    }
+                },
+                {
+                    "id": "6ae617a8-bc38-459a-8373-9378fe08585c",
+                    "name": "username",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "username",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "preferred_username",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "c01a8d7e-4250-4d67-bd29-355fad71abb0",
+                    "name": "zoneinfo",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "zoneinfo",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "zoneinfo",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "e5168440-f844-45c0-bdbf-72610e91b576",
+                    "name": "family name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "lastName",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "family_name",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "f8466f35-0a86-4832-9ff0-0a95f71829af",
+                    "name": "birthdate",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "birthdate",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "birthdate",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "e5b5a615-288c-4404-8482-fcecc483cb11",
+                    "name": "nickname",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "nickname",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "nickname",
+                        "jsonType.label": "String"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "b675492c-5060-4166-bd51-cdcec9637b60",
+            "name": "web-origins",
+            "description": "OpenID Connect scope for add allowed web origins to the access token",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "false",
+                "display.on.consent.screen": "false",
+                "consent.screen.text": ""
+            },
+            "protocolMappers": [
+                {
+                    "id": "0758705e-28f0-4174-a064-82dceb5ac5f0",
+                    "name": "allowed web origins",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-allowed-origins-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "access.token.claim": "true"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "781ab23f-afb3-4049-a234-362f84392465",
+            "name": "phone",
+            "description": "OpenID Connect built-in scope: phone",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+                "consent.screen.text": "${phoneScopeConsentText}"
+            },
+            "protocolMappers": [
+                {
+                    "id": "10fe8901-746e-485a-ad60-ebd414db22d9",
+                    "name": "phone number",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "phoneNumber",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "phone_number",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "7fe02213-8c44-4b36-a6b4-5c3531d8aef1",
+                    "name": "phone number verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "phoneNumberVerified",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "phone_number_verified",
+                        "jsonType.label": "boolean"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "0e8fab58-774d-4e0e-926e-62cbb6bcfa72",
+            "name": "roles",
+            "description": "OpenID Connect scope for add user roles to the access token",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "false",
+                "display.on.consent.screen": "true",
+                "consent.screen.text": "${rolesScopeConsentText}"
+            },
+            "protocolMappers": [
+                {
+                    "id": "37bebd01-0817-43f7-933c-219419691943",
+                    "name": "realm roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "multivalued": "true",
+                        "user.attribute": "foo",
+                        "access.token.claim": "true",
+                        "claim.name": "realm_access.roles",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "51a86f49-6ac4-4b0a-bb3b-a93bd58db463",
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "access.token.claim": "true"
+                    }
+                },
+                {
+                    "id": "b0e676ca-ed5d-4512-b438-8605f0586125",
+                    "name": "client roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-client-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "multivalued": "true",
+                        "user.attribute": "foo",
+                        "access.token.claim": "true",
+                        "claim.name": "resource_access.${client_id}.roles",
+                        "jsonType.label": "String"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "c8dd5664-76da-4f41-8c5a-c0689a664cbc",
+            "name": "offline_access",
+            "description": "OpenID Connect built-in scope: offline_access",
+            "protocol": "openid-connect",
+            "attributes": {
+                "consent.screen.text": "${offlineAccessScopeConsentText}",
+                "display.on.consent.screen": "true"
+            }
+        },
+        {
+            "id": "6065606a-4e3c-4b5d-accf-7bacbee9502c",
+            "name": "role_list",
+            "description": "SAML role list",
+            "protocol": "saml",
+            "attributes": {
+                "consent.screen.text": "${samlRoleListScopeConsentText}",
+                "display.on.consent.screen": "true"
+            },
+            "protocolMappers": [
+                {
+                    "id": "731780fc-20f0-4f2b-8089-328221620f7e",
+                    "name": "role list",
+                    "protocol": "saml",
+                    "protocolMapper": "saml-role-list-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "single": "false",
+                        "attribute.nameformat": "Basic",
+                        "attribute.name": "Role"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "1cc2837b-4acb-44c8-96dc-dcdd44e0a877",
+            "name": "address",
+            "description": "OpenID Connect built-in scope: address",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+                "consent.screen.text": "${addressScopeConsentText}"
+            },
+            "protocolMappers": [
+                {
+                    "id": "a5b5719e-7a8f-41a1-9d17-27360ccf9f11",
+                    "name": "address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-address-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "user.attribute.formatted": "formatted",
+                        "user.attribute.country": "country",
+                        "introspection.token.claim": "true",
+                        "user.attribute.postal_code": "postal_code",
+                        "userinfo.token.claim": "true",
+                        "user.attribute.street": "street",
+                        "id.token.claim": "true",
+                        "user.attribute.region": "region",
+                        "access.token.claim": "true",
+                        "user.attribute.locality": "locality"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "489f5a5c-e4f7-4287-b159-5ce6d38e3051",
+            "name": "microprofile-jwt",
+            "description": "Microprofile - JWT built-in scope",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "false"
+            },
+            "protocolMappers": [
+                {
+                    "id": "8d7bb37b-059c-485d-825a-36175b12aa1d",
+                    "name": "upn",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "username",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "upn",
+                        "jsonType.label": "String"
+                    }
+                },
+                {
+                    "id": "bf589d9d-1b42-41a8-8a6a-0da4c4c7632d",
+                    "name": "groups",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "multivalued": "true",
+                        "user.attribute": "foo",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "groups",
+                        "jsonType.label": "String"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "c34c4936-bb5d-40bf-8f72-141498a4566b",
+            "name": "email",
+            "description": "OpenID Connect built-in scope: email",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true",
+                "consent.screen.text": "${emailScopeConsentText}"
+            },
+            "protocolMappers": [
+                {
+                    "id": "fb3008dc-f1ce-4a44-b20c-f9abad13590b",
+                    "name": "email verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-property-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "emailVerified",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "email_verified",
+                        "jsonType.label": "boolean"
+                    }
+                },
+                {
+                    "id": "a3d2a16b-2d5e-4bed-9b45-859cbee9b118",
+                    "name": "email",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "introspection.token.claim": "true",
+                        "userinfo.token.claim": "true",
+                        "user.attribute": "email",
+                        "id.token.claim": "true",
+                        "access.token.claim": "true",
+                        "claim.name": "email",
+                        "jsonType.label": "String"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "95bca1ff-c542-47a6-bb20-854a6e865df2",
+            "name": "acr",
+            "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+            "protocol": "openid-connect",
+            "attributes": {
+                "include.in.token.scope": "false",
+                "display.on.consent.screen": "false"
+            },
+            "protocolMappers": [
+                {
+                    "id": "7004040f-e245-4b0e-a441-92cef653dffe",
+                    "name": "acr loa level",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-acr-mapper",
+                    "consentRequired": false,
+                    "config": {
+                        "id.token.claim": "true",
+                        "introspection.token.claim": "true",
+                        "access.token.claim": "true"
+                    }
+                }
+            ]
+        }
+    ],
+    "defaultDefaultClientScopes": [
+        "role_list",
+        "profile",
+        "email",
+        "roles",
+        "web-origins",
+        "acr"
+    ],
+    "defaultOptionalClientScopes": [
+        "offline_access",
+        "address",
+        "phone",
+        "microprofile-jwt"
+    ],
+    "browserSecurityHeaders": {
+        "contentSecurityPolicyReportOnly": "",
+        "xContentTypeOptions": "nosniff",
+        "referrerPolicy": "no-referrer",
+        "xRobotsTag": "none",
+        "xFrameOptions": "SAMEORIGIN",
+        "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+        "xXSSProtection": "1; mode=block",
+        "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+    },
+    "smtpServer": {},
+    "eventsEnabled": false,
+    "eventsListeners": [
+        "jboss-logging"
+    ],
+    "enabledEventTypes": [],
+    "adminEventsEnabled": false,
+    "adminEventsDetailsEnabled": false,
+    "identityProviders": [],
+    "identityProviderMappers": [],
+    "components": {
+        "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+            {
+                "id": "7d523311-4d11-4ce1-aa8a-88848139be58",
+                "name": "Allowed Client Scopes",
+                "providerId": "allowed-client-templates",
+                "subType": "anonymous",
+                "subComponents": {},
+                "config": {
+                    "allow-default-scopes": [
+                        "true"
+                    ]
+                }
+            },
+            {
+                "id": "628924a2-87cb-4dbc-b7f5-b1c37e326ca9",
+                "name": "Allowed Protocol Mapper Types",
+                "providerId": "allowed-protocol-mappers",
+                "subType": "anonymous",
+                "subComponents": {},
+                "config": {
+                    "allowed-protocol-mapper-types": [
+                        "saml-user-attribute-mapper",
+                        "saml-user-property-mapper",
+                        "oidc-full-name-mapper",
+                        "oidc-address-mapper",
+                        "oidc-usermodel-attribute-mapper",
+                        "oidc-sha256-pairwise-sub-mapper",
+                        "saml-role-list-mapper",
+                        "oidc-usermodel-property-mapper"
+                    ]
+                }
+            },
+            {
+                "id": "ec756279-ebb3-4251-8a98-c4f02c1433b7",
+                "name": "Trusted Hosts",
+                "providerId": "trusted-hosts",
+                "subType": "anonymous",
+                "subComponents": {},
+                "config": {
+                    "host-sending-registration-request-must-match": [
+                        "true"
+                    ],
+                    "client-uris-must-match": [
+                        "true"
+                    ]
+                }
+            },
+            {
+                "id": "f2c82bcb-f132-4d1d-9487-ea4872ea2656",
+                "name": "Max Clients Limit",
+                "providerId": "max-clients",
+                "subType": "anonymous",
+                "subComponents": {},
+                "config": {
+                    "max-clients": [
+                        "200"
+                    ]
+                }
+            },
+            {
+                "id": "1a9792c7-ec70-4cac-9927-a2af083136c3",
+                "name": "Consent Required",
+                "providerId": "consent-required",
+                "subType": "anonymous",
+                "subComponents": {},
+                "config": {}
+            },
+            {
+                "id": "b72d988f-7c96-4d83-95cb-e9ea6f9d1cf8",
+                "name": "Allowed Protocol Mapper Types",
+                "providerId": "allowed-protocol-mappers",
+                "subType": "authenticated",
+                "subComponents": {},
+                "config": {
+                    "allowed-protocol-mapper-types": [
+                        "oidc-usermodel-attribute-mapper",
+                        "saml-user-property-mapper",
+                        "oidc-address-mapper",
+                        "saml-user-attribute-mapper",
+                        "saml-role-list-mapper",
+                        "oidc-full-name-mapper",
+                        "oidc-sha256-pairwise-sub-mapper",
+                        "oidc-usermodel-property-mapper"
+                    ]
+                }
+            },
+            {
+                "id": "514f3f57-50a0-4124-99be-22ba675c1338",
+                "name": "Full Scope Disabled",
+                "providerId": "scope",
+                "subType": "anonymous",
+                "subComponents": {},
+                "config": {}
+            },
+            {
+                "id": "5b4a6ca6-1fbb-49b8-8386-520dc390a4f3",
+                "name": "Allowed Client Scopes",
+                "providerId": "allowed-client-templates",
+                "subType": "authenticated",
+                "subComponents": {},
+                "config": {
+                    "allow-default-scopes": [
+                        "true"
+                    ]
+                }
+            }
+        ],
+        "org.keycloak.keys.KeyProvider": [
+            {
+                "id": "d30e50aa-3234-40e9-809c-ae639ebb4132",
+                "name": "hmac-generated-hs512",
+                "providerId": "hmac-generated",
+                "subComponents": {},
+                "config": {
+                    "priority": [
+                        "100"
+                    ],
+                    "algorithm": [
+                        "HS512"
+                    ]
+                }
+            },
+            {
+                "id": "27f67f44-de62-43e1-8c12-9ef276f80518",
+                "name": "rsa-enc-generated",
+                "providerId": "rsa-enc-generated",
+                "subComponents": {},
+                "config": {
+                    "priority": [
+                        "100"
+                    ],
+                    "algorithm": [
+                        "RSA-OAEP"
+                    ]
+                }
+            },
+            {
+                "id": "94b191a8-de15-48dc-86fb-4a647479f7ad",
+                "name": "aes-generated",
+                "providerId": "aes-generated",
+                "subComponents": {},
+                "config": {
+                    "priority": [
+                        "100"
+                    ]
+                }
+            },
+            {
+                "id": "c20abb83-0d1a-4c40-8ddf-6f58193acaf9",
+                "name": "rsa-generated",
+                "providerId": "rsa-generated",
+                "subComponents": {},
+                "config": {
+                    "priority": [
+                        "100"
+                    ]
+                }
+            }
+        ]
+    },
+    "internationalizationEnabled": false,
+    "supportedLocales": [],
+    "authenticationFlows": [
+        {
+            "id": "94299f21-6a01-4c31-8d28-73cc791fd5b7",
+            "alias": "Account verification options",
+            "description": "Method with which to verity the existing account",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "idp-email-verification",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Verify Existing Account by Re-authentication",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "cb200fb2-2f64-4041-9b06-6a7738dd55f5",
+            "alias": "Browser - Conditional OTP",
+            "description": "Flow to determine if the OTP is required for the authentication",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "d03eac50-ab2e-4c19-b2ff-4d324279ce82",
+            "alias": "Direct Grant - Conditional OTP",
+            "description": "Flow to determine if the OTP is required for the authentication",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "direct-grant-validate-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "125c1980-7898-489f-a0cd-c4831007a675",
+            "alias": "First broker login - Conditional OTP",
+            "description": "Flow to determine if the OTP is required for the authentication",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "3497caf5-ca17-4b62-9ddf-1c8496ef794b",
+            "alias": "Handle Existing Account",
+            "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "idp-confirm-link",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Account verification options",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "cc4aa349-eb17-4328-91df-a90094a86027",
+            "alias": "Reset - Conditional OTP",
+            "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "reset-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "0f1a23fb-8d60-48cb-8a6c-4c7fd59bb8f0",
+            "alias": "User creation or linking",
+            "description": "Flow for the existing/non-existing user alternatives",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticatorConfig": "create unique user config",
+                    "authenticator": "idp-create-user-if-unique",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Handle Existing Account",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "4c2694ed-606b-47b7-a677-e894cfe23810",
+            "alias": "Verify Existing Account by Re-authentication",
+            "description": "Reauthentication of existing account",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "idp-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "First broker login - Conditional OTP",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "91cfa1f0-afda-4479-a141-4af76e821ee2",
+            "alias": "browser",
+            "description": "browser based authentication",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "auth-cookie",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "auth-spnego",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "identity-provider-redirector",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 25,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "forms",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "d2239232-0bd1-4401-b5db-ce758ab2045a",
+            "alias": "clients",
+            "description": "Base authentication for clients",
+            "providerId": "client-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "client-secret",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "client-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "client-secret-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "client-x509",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 40,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "cb75fb9a-ca5e-45a6-987e-4f5fa022cc37",
+            "alias": "direct grant",
+            "description": "OpenID Connect Resource Owner Grant",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "direct-grant-validate-username",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "direct-grant-validate-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Direct Grant - Conditional OTP",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "2b3b24c5-9d61-4d12-916f-d2b96955f7bb",
+            "alias": "docker auth",
+            "description": "Used by Docker clients to authenticate against the IDP",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "docker-http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "3db62551-233e-4e32-afa9-906275424885",
+            "alias": "first broker login",
+            "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticatorConfig": "review profile config",
+                    "authenticator": "idp-review-profile",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "User creation or linking",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "dd17af69-b23e-4b86-be56-8465e77e1b44",
+            "alias": "forms",
+            "description": "Username, password, otp and other auth forms.",
+            "providerId": "basic-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "auth-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Browser - Conditional OTP",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "480cbdff-2d94-438e-8572-75f8cb099706",
+            "alias": "registration",
+            "description": "registration flow",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "registration-page-form",
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": true,
+                    "flowAlias": "registration form",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "70bbffaa-4aeb-4256-b25a-25098454d4bf",
+            "alias": "registration form",
+            "description": "registration form",
+            "providerId": "form-flow",
+            "topLevel": false,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "registration-user-creation",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "registration-password-action",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 50,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "registration-recaptcha-action",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 60,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "registration-terms-and-conditions",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 70,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "6b9a1811-44d4-48e2-a8d0-a9df9fca7c49",
+            "alias": "reset credentials",
+            "description": "Reset credentials for a user if they forgot their password or something",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "reset-credentials-choose-user",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "reset-credential-email",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticator": "reset-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                },
+                {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 40,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Reset - Conditional OTP",
+                    "userSetupAllowed": false
+                }
+            ]
+        },
+        {
+            "id": "507afdda-ab77-4512-93eb-a72fa14a73a4",
+            "alias": "saml ecp",
+            "description": "SAML ECP Profile Authentication Flow",
+            "providerId": "basic-flow",
+            "topLevel": true,
+            "builtIn": true,
+            "authenticationExecutions": [
+                {
+                    "authenticator": "http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                }
+            ]
+        }
+    ],
+    "authenticatorConfig": [
+        {
+            "id": "cb9ff312-5cc6-4783-9bc3-0ce41ccf4515",
+            "alias": "create unique user config",
+            "config": {
+                "require.password.update.after.registration": "false"
+            }
+        },
+        {
+            "id": "4ea5f2f9-94c3-4c84-8b8e-79f53b103734",
+            "alias": "review profile config",
+            "config": {
+                "update.profile.on.first.login": "missing"
+            }
+        }
+    ],
+    "requiredActions": [
+        {
+            "alias": "CONFIGURE_TOTP",
+            "name": "Configure OTP",
+            "providerId": "CONFIGURE_TOTP",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 10,
+            "config": {}
+        },
+        {
+            "alias": "TERMS_AND_CONDITIONS",
+            "name": "Terms and Conditions",
+            "providerId": "TERMS_AND_CONDITIONS",
+            "enabled": false,
+            "defaultAction": false,
+            "priority": 20,
+            "config": {}
+        },
+        {
+            "alias": "UPDATE_PASSWORD",
+            "name": "Update Password",
+            "providerId": "UPDATE_PASSWORD",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 30,
+            "config": {}
+        },
+        {
+            "alias": "UPDATE_PROFILE",
+            "name": "Update Profile",
+            "providerId": "UPDATE_PROFILE",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 40,
+            "config": {}
+        },
+        {
+            "alias": "VERIFY_EMAIL",
+            "name": "Verify Email",
+            "providerId": "VERIFY_EMAIL",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 50,
+            "config": {}
+        },
+        {
+            "alias": "delete_account",
+            "name": "Delete Account",
+            "providerId": "delete_account",
+            "enabled": false,
+            "defaultAction": false,
+            "priority": 60,
+            "config": {}
+        },
+        {
+            "alias": "webauthn-register",
+            "name": "Webauthn Register",
+            "providerId": "webauthn-register",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 70,
+            "config": {}
+        },
+        {
+            "alias": "webauthn-register-passwordless",
+            "name": "Webauthn Register Passwordless",
+            "providerId": "webauthn-register-passwordless",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 80,
+            "config": {}
+        },
+        {
+            "alias": "VERIFY_PROFILE",
+            "name": "Verify Profile",
+            "providerId": "VERIFY_PROFILE",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 90,
+            "config": {}
+        },
+        {
+            "alias": "delete_credential",
+            "name": "Delete Credential",
+            "providerId": "delete_credential",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 100,
+            "config": {}
+        },
+        {
+            "alias": "update_user_locale",
+            "name": "Update User Locale",
+            "providerId": "update_user_locale",
+            "enabled": true,
+            "defaultAction": false,
+            "priority": 1000,
+            "config": {}
+        }
+    ],
+    "browserFlow": "browser",
+    "registrationFlow": "registration",
+    "directGrantFlow": "direct grant",
+    "resetCredentialsFlow": "reset credentials",
+    "clientAuthenticationFlow": "clients",
+    "dockerAuthenticationFlow": "docker auth",
+    "firstBrokerLoginFlow": "first broker login",
+    "attributes": {
+        "cibaBackchannelTokenDeliveryMode": "poll",
+        "cibaExpiresIn": "120",
+        "cibaAuthRequestedUserHint": "login_hint",
+        "oauth2DeviceCodeLifespan": "600",
+        "oauth2DevicePollingInterval": "5",
+        "parRequestUriLifespan": "60",
+        "cibaInterval": "5",
+        "realmReusableOtpCode": "false"
+    },
+    "keycloakVersion": "24.0.3",
+    "userManagedAccessAllowed": false,
+    "clientProfiles": {
+        "profiles": []
+    },
+    "clientPolicies": {
+        "policies": []
+    }
+}


### PR DESCRIPTION
Closes #28.

Adds OIDC JWT validation to the server alongside the existing static-token auth, then wires up Keycloak as the identity provider behind the Caddy proxy.

## What's in here

**OIDC validator (`f91eed2`)** — `OidcValidator` fetches the IdP's discovery doc and JWKS, verifies signatures (RS256 / ES256 / ES384), and checks `iss`, `aud`, `exp`, and `nbf`. JWKS and discovery responses are cached with TTLs (5 min / 1 hour) and JWKS is refetched once on unknown `kid` to handle key rotation. Issuer URL and discovery URL are split so the server can fetch keys over an internal hostname (e.g. `http://keycloak:8080` inside Docker) while still validating tokens against the public issuer claim. Audience is configurable. `aud` is parsed as either a string or array to accept Keycloak's real-world tokens.

**Keycloak deploy (`50ec489`)** — `auth.devchris.dev` is fronted by Caddy and runs Keycloak with `realm-cloudsync.json` imported on first boot. CloudSync talks to it over the internal docker network. H2 lives on a host volume so users and rotated passwords survive restarts.

## Verified locally

Booted Keycloak locally, created the realm + client + audience mapper, fetched a token via direct grant, and confirmed the cloudsync server validates it end-to-end (signature, issuer, audience).

## Before deploying to Hetzner

- `mkdir -p /mnt/volume-cloudsync/keycloak && chown 1000:1000 /mnt/volume-cloudsync/keycloak` (Keycloak runs as uid 1000; cloudsync and caddy run as root which is why their dirs don't need a chown — see `docs/server-setup.md`).
- Add `CLOUDSYNC_KEYCLOAK_DATA_DIR`, `CLOUDSYNC_KC_ADMIN`, `CLOUDSYNC_KC_ADMIN_PASSWORD` to the deploy workflow's env block.
- Cloudflare DNS for `auth.devchris.dev` → grey cloud (DNS only) so Caddy can complete the ACME HTTP-01 challenge.
- The production deploy hasn't been tested end-to-end yet. Worth a smoke test before merging.

## Follow-ups (deliberately not in this PR)

- JWKS refresh and HTTP hardening (`docs/plan-oidc-hardening.md` items 5 & 6) — partial; revisit timeouts and body-size caps.
- Harden cloudsync/caddy images to run as non-root, then chown their volumes too.
- Migrate Keycloak's H2 to Postgres when there are real users worth protecting.