### PR TITLE
Make deploy reliably ship config changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,11 @@ jobs:
           echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           scp -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key docker-compose.yml root@46.224.102.7:~/docker-compose.yml
-          scp -r -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key caddy root@46.224.102.7:~/caddy
-          scp -r -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key observability root@46.224.102.7:~/observability
+          # rsync (not scp -r) so config dirs are mirrored, not nested inside
+          # themselves on subsequent deploys. --delete drops files removed in
+          # the repo so stale configs can't outlive a deploy.
+          rsync -az --delete -e "ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key" caddy/ root@46.224.102.7:~/caddy/
+          rsync -az --delete -e "ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key" observability/ root@46.224.102.7:~/observability/
           ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key root@46.224.102.7 << EOF
             # Loki runs as UID 10001, Grafana as UID 472 — ensure their data
             # dirs exist on the volume with correct ownership before first start.
@@ -42,4 +45,12 @@ jobs:
             CLOUDSYNC_GRAFANA_MOUNT_DIR=/mnt/volume-cloudsync/grafana \
             CLOUDSYNC_GRAFANA_ADMIN_PASSWORD=$CLOUDSYNC_GRAFANA_ADMIN_PASSWORD \
             docker compose -f ~/docker-compose.yml up -d
+
+            # Compose only restarts a service when its spec changes; bind-mounted
+            # config files (Caddyfile, Loki/Promtail/Grafana configs) are invisible
+            # to that check. Force the consumers to re-read them. xargs -r skips
+            # the call entirely if a service isn't running, instead of erroring.
+            for svc in reverse-proxy loki promtail grafana; do
+              docker ps -q --filter "name=\$svc" | xargs -r docker restart
+            done
           EOF


### PR DESCRIPTION
Two deploy bugs surfaced when rolling out the observability stack (#30). Neither was a problem until we had two `scp -r` config dirs and started editing files Caddy already had mounted — but they were both latent the whole time.

## Bug 1: `scp -r` nests on second deploy

```sh
scp -r caddy root@host:~/caddy
```

The first deploy creates `~/caddy/Caddyfile` — fine. The second deploy creates `~/caddy/caddy/Caddyfile` — wrong. Bind-mounted as `/etc/caddy`, the container reads the *original* top-level file (untouched since the first deploy) and ignores the nested directory.

In our case, that meant the merged Caddyfile with the new monitoring vhost never reached Caddy at all. Caddy kept serving the pre-PR config from April.

**Fix:** `rsync -az --delete` with trailing slashes mirrors directory *contents*, not the directory itself. Idempotent across any number of deploys, and `--delete` ensures files removed in the repo also disappear on the server.

## Bug 2: compose doesn't restart on bind-mount content changes

`docker compose up -d` decides whether to recreate a container by hashing its *spec* — image, env, ports, volume specs. The *contents* of bind-mounted files are invisible to that hash, so even after the new Caddyfile was on disk, the running Caddy container kept its old config in memory until manually restarted.

**Fix:** explicitly `docker restart` the four containers that mount config (Caddy, Loki, Promtail, Grafana) after `up -d`. `xargs -r` skips quietly if a container isn't running rather than failing the deploy. The Rust app container is left alone — its spec changes whenever the image tag does, which compose handles correctly.

## Why both in one PR

Both are one-line categories of "deploy silently doesn't ship config." Found together, fix together — testing one without the other still leaves a broken happy-path. Net diff is +13/-2 in `deploy.yml`.

## Verification

I can't easily test this end-to-end locally (no second VPS), but:
- The bash heredoc escape was checked manually by simulating Actions-side variable expansion.
- The rsync invocation is the canonical "mirror this directory" form.
- The for-loop is shellcheck-clean.

Will be verified on the next real deploy.