### PR TITLE
OIDC/JWT validation + Keycloak deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
           DEPLOY_SSH_KEY: ${{ secrets.CLOUDSYNC_HETZNER_PRIVATE_KEY }}
           CLOUDSYNC_TOKEN: ${{ secrets.CLOUDSYNC_TOKEN }}
           CLOUDSYNC_GRAFANA_ADMIN_PASSWORD: ${{ secrets.CLOUDSYNC_GRAFANA_ADMIN_PASSWORD }}
+          CLOUDSYNC_KC_ADMIN: ${{ secrets.CLOUDSYNC_KC_ADMIN }}
+          CLOUDSYNC_KC_ADMIN_PASSWORD: ${{ secrets.CLOUDSYNC_KC_ADMIN_PASSWORD }}
         run: |
           mkdir -p ~/.ssh
           echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
@@ -44,6 +46,9 @@ jobs:
             CLOUDSYNC_LOKI_MOUNT_DIR=/mnt/volume-cloudsync/loki \
             CLOUDSYNC_GRAFANA_MOUNT_DIR=/mnt/volume-cloudsync/grafana \
             CLOUDSYNC_GRAFANA_ADMIN_PASSWORD=$CLOUDSYNC_GRAFANA_ADMIN_PASSWORD \
+            CLOUDSYNC_KC_DATA_DIR=/mnt/volume-cloudsync/keycloak \
+            CLOUDSYNC_KC_ADMIN=$CLOUDSYNC_KC_ADMIN \
+            CLOUDSYNC_KC_ADMIN_PASSWORD=$CLOUDSYNC_KC_ADMIN_PASSWORD \
             docker compose -f ~/docker-compose.yml up -d
 
             # Compose only restarts a service when its spec changes; bind-mounted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,9 @@ Rust toolchain pinned to **1.91.1** via `rust-toolchain.toml`.
 
 PR checks (`.github/workflows/ci.yml`): rustfmt, clippy with `--deny warnings`, tests. Docs/markdown changes skip CI.
 
-Release (`.github/workflows/release.yml`): on `v*` tags — GitHub release, Docker image to GHCR, deploy to Hetzner.
+Release (`.github/workflows/release.yml`): on `v*` tags — builds cross-platform client binaries + a server binary, creates a GitHub release with auto-generated notes, and pushes the server Docker image to GHCR (tagged with the version and `latest`).
+
+Deploy (`.github/workflows/deploy.yml`): manual `workflow_dispatch` trigger — SSHes to Hetzner, copies `docker-compose.yml` and config dirs, and runs `docker compose up -d` with the chosen image tag. The split is deliberate: tagging publishes artifacts; deploy chooses what's running. To roll back, trigger Deploy with an earlier version tag.
 
 ## Key Patterns
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     # rotated passwords). Treat the JSON as bootstrap, not source of truth.
     command: ["start", "--import-realm"]
     volumes:
-      - ${CLOUDSYNC_KEYCLOAK_DATA_DIR}:/opt/keycloak/data
+      - ${CLOUDSYNC_KC_DATA_DIR}:/opt/keycloak/data
       - ./keycloak/realm-cloudsync.json:/opt/keycloak/data/import/realm-cloudsync.json:ro
     restart: unless-stopped
 

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -38,7 +38,7 @@ mkdir -p /mnt/volume-cloudsync/{cloudsync,caddy,keycloak}
 | ---------- | ----------------------------- | -------------------------------------- |
 | `cloudsync/` | `CLOUDSYNC_MOUNT_DIR`         | cloudsync server: file storage + redb  |
 | `caddy/`     | `CLOUDSYNC_CADDY_MOUNT_DIR`   | caddy: Let's Encrypt certs, state      |
-| `keycloak/`  | `CLOUDSYNC_KEYCLOAK_DATA_DIR` | keycloak: H2 database, signing keys    |
+| `keycloak/`  | `CLOUDSYNC_KC_DATA_DIR`       | keycloak: H2 database, signing keys    |
 
 ### Permissions
 
@@ -92,14 +92,56 @@ For the observability stack (see §7), also set `CLOUDSYNC_GRAFANA_ADMIN_PASSWOR
 gh secret set CLOUDSYNC_GRAFANA_ADMIN_PASSWORD
 ```
 
-## 6. First Deploy
+### GitHub secrets used by `deploy.yml`
 
-The release workflow (`.github/workflows/release.yml`) handles:
+| Secret                             | What it's for                                      |
+| ---------------------------------- | -------------------------------------------------- |
+| `CLOUDSYNC_HETZNER_PRIVATE_KEY`    | SSH key for the deploy user on the VPS             |
+| `CLOUDSYNC_TOKEN`                  | Static bearer token for the API (fallback auth)    |
+| `CLOUDSYNC_GRAFANA_ADMIN_PASSWORD` | Grafana admin password                             |
+| `CLOUDSYNC_KC_ADMIN`               | Keycloak bootstrap admin username                  |
+| `CLOUDSYNC_KC_ADMIN_PASSWORD`      | Keycloak bootstrap admin password (rotate after 1st login) |
 
-- Building and pushing the Docker image to ghcr.io
-- SSHing into the server
-- Copying `docker-compose.yml` to the server
-- Running `docker compose up -d` with env vars for image tag, mount dir, and token
+## 6. Release and Deploy
+
+Two separate steps: tag a release to publish artifacts, then trigger a
+deploy to roll it out. Splitting them lets you publish without deploying,
+deploy any past tag (rollback), or re-deploy the same tag without re-tagging.
+
+### Release
+
+```sh
+git checkout main && git pull
+git tag -a v0.3.0 -m "Short summary of what's in this release"
+git push origin v0.3.0
+```
+
+The release workflow (`release.yml`) triggers on the tag push and:
+
+- Builds client binaries for linux x86_64/aarch64 and macOS intel/arm
+- Builds the server binary for linux x86_64
+- Creates a GitHub release with auto-generated notes
+- Pushes the server Docker image to `ghcr.io/devchris123/cloudsync-server`
+  with tags `:<version>` and `:latest`
+
+Takes ~10 minutes for all targets. Watch progress in the Actions tab.
+
+### Deploy
+
+After the release workflow finishes, trigger a deploy:
+
+```sh
+gh workflow run deploy.yml -f version=v0.3.0
+```
+
+Or via the GitHub UI: Actions → Deploy → Run workflow → enter the version.
+
+The deploy workflow (`deploy.yml`) SSHes to the VPS, copies the current
+repo's `docker-compose.yml` and config dirs (caddy, observability), and
+runs `docker compose up -d` with env vars pointing at the chosen image
+tag. The compose file shipped is the one at `HEAD` of `main` at deploy
+time, not the one at the tagged commit — keep that in mind if you ever
+need to deploy an old version against a new compose layout.
 
 ## 7. Observability (Grafana + Loki + Promtail)
 


### PR DESCRIPTION
Adds OIDC JWT validation alongside the static-token auth path and stands up Keycloak as the IdP behind Caddy.

## What's in this branch

- **OIDC validation + auth layer** — JWT verification middleware running in parallel with the existing static-token path. Tokens are validated against the configured issuer's JWKS; static token still works as fallback.
- **Hardening pass** — split `CLOUDSYNC_OIDC_ISSUER` (public, matched against `iss`) from `CLOUDSYNC_OIDC_DISCOVERY_URL` (used to fetch JWKS, may be an internal hostname). Treats discovery URL as integrity-critical.
- **Keycloak service** — added to `docker-compose.yml` with `--import-realm` bootstrapping from `realm-cloudsync.json`. Subsequent boots preserve in-place changes.
- **Deploy wiring (this commit)** — `\$CLOUDSYNC_KC_ADMIN`, `\$CLOUDSYNC_KC_ADMIN_PASSWORD`, and `\$CLOUDSYNC_KC_DATA_DIR` were referenced by compose but never exported by the deploy workflow. Sourced the admin creds from new GitHub secrets and pinned the data dir to `/mnt/volume-cloudsync/keycloak`. Renamed `CLOUDSYNC_KEYCLOAK_DATA_DIR` → `CLOUDSYNC_KC_DATA_DIR` for consistency with the other `KC_*` names.
- **Docs** — split §6 in `server-setup.md` into Release vs Deploy (matches the workflow split), added a GitHub-secrets table.

## Before merging

Add the two new GitHub secrets, otherwise the next deploy will start Keycloak with empty admin creds:

\`\`\`sh
gh secret set CLOUDSYNC_KC_ADMIN
gh secret set CLOUDSYNC_KC_ADMIN_PASSWORD
\`\`\`

Closes #28.